### PR TITLE
Fix test_tag

### DIFF
--- a/test/test_tag.rb
+++ b/test/test_tag.rb
@@ -3,6 +3,8 @@ require File.dirname(__FILE__) + '/helper'
 class TestTag < Test::Unit::TestCase
   def setup
     @r = Repo.new(File.join(File.dirname(__FILE__), *%w[dot_git]), :is_bare => true)
+    @tags = {}
+    @r.tags.each {|t| @tags[t.name] = t}
   end
 
   # list_from_string size
@@ -14,7 +16,7 @@ class TestTag < Test::Unit::TestCase
   # list_from_string
 
   def test_list_from_string
-    tag = @r.tags[1]
+    tag = @tags['not_annotated']
 
     assert_equal 'not_annotated', tag.name
     assert_equal 'ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a', tag.commit.id
@@ -23,7 +25,7 @@ class TestTag < Test::Unit::TestCase
   # list_from_string_for_signed_tag
 
   def test_list_from_string_for_signed_tag
-    tag = @r.tags[2]
+    tag = @tags['v0.7.0']
 
     assert_equal 'v0.7.0', tag.name
     assert_equal '7bcc0ee821cdd133d8a53e8e7173a334fef448aa', tag.commit.id
@@ -32,7 +34,7 @@ class TestTag < Test::Unit::TestCase
   # list_from_string_for_annotated_tag
 
   def test_list_from_string_for_annotated_tag
-    tag = @r.tags.first
+    tag = @tags['annotated']
 
     assert_equal 'annotated', tag.name
     assert_equal 'ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a', tag.commit.id
@@ -41,7 +43,7 @@ class TestTag < Test::Unit::TestCase
   # list_from_string_for_packed_tag
 
   def test_list_from_string_for_packed_tag
-    tag = @r.tags[4]
+    tag = @tags['packed']
 
     assert_equal 'packed', tag.name
     assert_equal 'ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a', tag.commit.id
@@ -50,7 +52,7 @@ class TestTag < Test::Unit::TestCase
   # list_from_string_for_packed_annotated_tag
 
   def test_list_from_string_for_packed_annotated_tag
-    tag = @r.tags[3]
+    tag = @tags['packed_annotated']
 
     assert_equal 'packed_annotated', tag.name
     assert_equal '7bcc0ee821cdd133d8a53e8e7173a334fef448aa', tag.commit.id
@@ -77,7 +79,7 @@ class TestTag < Test::Unit::TestCase
   # reads_light_tag_contents
 
   def test_reads_light_tag_contents
-    tag = @r.tags[1]
+    tag = @tags['not_annotated']
     assert_equal 'not_annotated', tag.name
     assert_equal 'added a pure-ruby git library and converted the cat_file commands to use it',
       tag.message
@@ -89,7 +91,7 @@ class TestTag < Test::Unit::TestCase
   # reads_annotated_tag_contents
 
   def test_reads_annotated_tag_contents
-    tag = @r.tags[0]
+    tag = @tags['annotated']
     assert_equal 'annotated',       tag.name
     assert_equal 'Annotated tag.',  tag.message
     assert_equal 'Chris Wanstrath', tag.tagger.name
@@ -113,7 +115,7 @@ TAG
   # reads_annotated_and_packed_tag_contents
 
   def test_reads_annotated_and_packed_tag_contents
-    tag = @r.tags[3]
+    tag = @tags['packed_annotated']
     assert_equal 'packed_annotated',   tag.name
     assert_equal 'v0.7.0',             tag.message
     assert_equal 'Tom Preston-Werner', tag.tagger.name
@@ -124,7 +126,7 @@ TAG
   # inspect
 
   def test_inspect
-    tag = @r.tags.last
+    tag = @tags['v0.7.0']
 
     assert_equal %Q{#<Grit::Tag "#{tag.name}">}, tag.inspect
   end


### PR DESCRIPTION
http://github.com/mojombo/grit/issues/issue/34

Sort output of Dir::glob() instead of assuming that Dir::glob() sorts stuff.
