### PR TITLE
Grit::Git#sh and internal pack performance

### DIFF
--- a/lib/grit/git-ruby/internal/pack.rb
+++ b/lib/grit/git-ruby/internal/pack.rb
@@ -317,7 +317,7 @@ module Grit
               if indata.size == 0
                 raise PackFormatError, 'error reading pack data'
               end
-              outdata += zstr.inflate(indata)
+              outdata << zstr.inflate(indata)
             end
             if outdata.size > destsize
               raise PackFormatError, 'error reading pack data'
@@ -351,9 +351,9 @@ module Grit
               cp_size |= delta.getord(pos += 1) << 16 if c & 0x40 != 0
               cp_size = 0x10000 if cp_size == 0
               pos += 1
-              dest += base[cp_off,cp_size]
+              dest << base[cp_off,cp_size]
             elsif c != 0
-              dest += delta[pos,c]
+              dest << delta[pos,c]
               pos += c
             else
               raise PackFormatError, 'invalid delta data'

--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -255,28 +255,23 @@ module Grit
 
     def sh(command, &block)
       ret, err = '', ''
+      max = self.class.git_max_size
       Open3.popen3(command) do |stdin, stdout, stderr|
         block.call(stdin) if block
         Timeout.timeout(self.class.git_timeout) do
           while tmp = stdout.read(1024)
-            ret += tmp
-            if (@bytes_read += tmp.size) > self.class.git_max_size
-              bytes = @bytes_read
-              @bytes_read = 0
-              raise GitTimeout.new(command, bytes)
-            end
+            ret << tmp
+            raise GitTimeout.new(command, ret.size) if ret.size > max
           end
         end
 
         while tmp = stderr.read(1024)
-          err += tmp
+          err << tmp
         end
       end
       [ret, err]
     rescue Timeout::Error, Grit::Git::GitTimeout
-      bytes = @bytes_read
-      @bytes_read = 0
-      raise GitTimeout.new(command, bytes)
+      raise GitTimeout.new(command, ret.size)
     end
 
     def wild_sh(command, &block)
@@ -284,11 +279,11 @@ module Grit
       Open3.popen3(command) do |stdin, stdout, stderr|
         block.call(stdin) if block
         while tmp = stdout.read(1024)
-          ret += tmp
+          ret << tmp
         end
 
         while tmp = stderr.read(1024)
-          err += tmp
+          err << tmp
         end
       end
       [ret, err]

--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -259,13 +259,13 @@ module Grit
       Open3.popen3(command) do |stdin, stdout, stderr|
         block.call(stdin) if block
         Timeout.timeout(self.class.git_timeout) do
-          while tmp = stdout.read(1024)
+          while tmp = stdout.read(8192)
             ret << tmp
             raise GitTimeout.new(command, ret.size) if ret.size > max
           end
         end
 
-        while tmp = stderr.read(1024)
+        while tmp = stderr.read(8192)
           err << tmp
         end
       end
@@ -278,11 +278,11 @@ module Grit
       ret, err = '', ''
       Open3.popen3(command) do |stdin, stdout, stderr|
         block.call(stdin) if block
-        while tmp = stdout.read(1024)
+        while tmp = stdout.read(8192)
           ret << tmp
         end
 
-        while tmp = stderr.read(1024)
+        while tmp = stderr.read(8192)
           err << tmp
         end
       end

--- a/test/test_git.rb
+++ b/test/test_git.rb
@@ -49,9 +49,8 @@ class TestGit < Test::Unit::TestCase
   end
 
   def test_raises_if_too_many_bytes
-    @git.instance_variable_set(:@bytes_read, 6000000)
     assert_raises Grit::Git::GitTimeout do
-      @git.version
+      @git.sh "yes | head -#{Grit::Git.git_max_size + 1}"
     end
   end
 


### PR DESCRIPTION
This speeds native calls with largish output and also the internal unpack stuff. The biggest win comes from using `String#<<` instead of `String#+` when buffering, especially under some versions of Rails (AS) where `String#+` is made to be extremely slow. Increasing the read buffer sizes helped a bit too, though not as much.

With 500K blob, before:

```
$ ruby bench-string-concat.rb 12044a76034e894c2412aea9c20508b5c8277784
blob: 12044a76034e894c2412aea9c20508b5c8277784
size: 499855
                                    user     system      total        real
native cat_file                11.030000   9.140000  20.230000 ( 21.182163)
ruby cat_file                   0.040000   0.020000   0.060000 (  0.061033)
```

ActiveSupport makes it even worse:

```
$ ruby -ractive_support bench-string-concat.rb 12044a76034e894c2412aea9c20508b5c8277784
blob: 12044a76034e894c2412aea9c20508b5c8277784
size: 499855
                                    user     system      total        real
native cat_file                15.830000   9.570000  25.470000 ( 26.286903)
ruby cat_file                   0.050000   0.020000   0.070000 (  0.073557)
```

With this commit applied (using String#<< instead of String#+):

```
$ ruby bench-string-concat.rb 12044a76034e894c2412aea9c20508b5c8277784
blob: 12044a76034e894c2412aea9c20508b5c8277784
size: 499855
                                    user     system      total        real
native cat_file                 0.310000   0.440000   0.800000 (  1.765703)
ruby cat_file                   0.040000   0.020000   0.060000 (  0.064426)
```

The `bench-string-concat.rb` script is here:

https://gist.github.com/e749138b066ed9d81fbe
