### PR TITLE
Improved repository check in Repo#initialize

### DIFF
--- a/test/test_commit_stats.rb
+++ b/test/test_commit_stats.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/helper'
 class TestCommitStats < Test::Unit::TestCase
 
   def setup
-    File.expects(:exist?).returns(true)
+    File.expects(:exist?).times(3).returns(true)
     @r = Repo.new(GRIT_REPO)
 
     Git.any_instance.expects(:log).returns(fixture('log'))


### PR DESCRIPTION
I reworked the repository checks in `Repo#initialize` to be more accurate in detecting (bare) Git repositories. This is a bit smarter than the old approach which is based on path names only. Additionally it checks the Git repository structure for `HEAD`, `objects` and `refs` which is the minimal repo layout.
