### PR TITLE
Fixed Repo.init_bare for path names not ending with ".git"

### DIFF
--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -99,6 +99,7 @@ module Grit
       git = Git.new(path)
       git.fs_mkdir('..')
       git.init(git_options)
+      repo_options = {:is_bare => true}.merge(repo_options)
       self.new(path, repo_options)
     end
 

--- a/test/test_repo.rb
+++ b/test/test_repo.rb
@@ -181,9 +181,12 @@ class TestRepo < Test::Unit::TestCase
   def test_init_bare
     FileUtils.stubs(:mkdir_p)
 
-    Git.any_instance.expects(:init).returns(true)
-    Repo.expects(:new).with("/foo/bar.git", {})
+    Git.any_instance.expects(:init).with(:bare => true).returns(true).twice
+    Repo.expects(:new).with("/foo/bar.git", {:is_bare => true})
     Repo.init_bare("/foo/bar.git")
+
+    Repo.expects(:new).with("/foo/bar", {:is_bare => true})
+    Repo.init_bare("/foo/bar")
   end
 
   def test_init_bare_with_options
@@ -191,7 +194,7 @@ class TestRepo < Test::Unit::TestCase
 
     Git.any_instance.expects(:init).with(
       :bare => true, :template => "/baz/sweet").returns(true)
-    Repo.expects(:new).with("/foo/bar.git", {})
+    Repo.expects(:new).with("/foo/bar.git", {:is_bare => true})
     Repo.init_bare("/foo/bar.git", :template => "/baz/sweet")
   end
 


### PR DESCRIPTION
`Repo.init_bare` does not pass option `:is_bare => true` to `Repo#initialize`.
Therefore, the created `Repo` instance is non-bare if the supplied path name does not end with `.git`.
