### PR TITLE
Fix for issue in Repo#diff

### DIFF
--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -502,7 +502,7 @@ module Grit
       diff = self.git.native('diff', {}, a, b, '--', *paths)
 
       if diff =~ /diff --git a/
-        diff = diff.sub(/.+?(diff --git a)/m, '\1')
+        diff = diff.sub(/.*?(diff --git a)/m, '\1')
       else
         diff = ''
       end

--- a/test/test_repo.rb
+++ b/test/test_repo.rb
@@ -234,6 +234,13 @@ class TestRepo < Test::Unit::TestCase
     @r.diff('master^', 'master', 'foo/bar', 'foo/baz')
   end
 
+  def test_diff2
+    Git.any_instance.expects(:native).with('diff', {}, 'a', 'b', '--').returns(fixture('diff_p'))
+    diffs = @r.diff('a', 'b')
+
+    assert_equal 15, diffs.size
+  end
+
   # commit_diff
 
   def test_diff


### PR DESCRIPTION
I think there's an issue with the following line in Repo#diff:

diff.sub(/.+?(diff --git a)/m, '\1')

Is the intention to strip everything up to the first occurrence of "diff --git a"? If so, then it should probably be ".*" instead of ".+". Otherwise, it ends up stripping the entire first diff if there are not characters before "diff --git".

Anyway, here's a fix & a test for it.
