### PR TITLE
Use appropriate working tree in git commands

### DIFF
--- a/lib/grit/actor.rb
+++ b/lib/grit/actor.rb
@@ -40,7 +40,8 @@ module Grit
       end
       hours = (time.utc_offset.to_f / 3600).to_i # 60 * 60, seconds to hours
       rem   = time.utc_offset.abs % 3600
-      out << " #{time.to_i} #{hours >= 0 ? :+ : :-}#{hours.abs.to_s.rjust(2, '0')}#{rem.to_s.rjust(2, '0')}"
+      mins = rem.div 60 # convert seconds to minutes; any remainder is discarded
+      out << " #{time.to_i} #{hours >= 0 ? :+ : :-}#{hours.abs.to_s.rjust(2, '0')}#{mins.to_s.rjust(2, '0')}"
     end
 
     # Pretty object inspection

--- a/lib/grit/git-ruby.rb
+++ b/lib/grit/git-ruby.rb
@@ -223,19 +223,10 @@ module Grit
         Timeout.timeout(self.class.git_timeout) do
           ret = yield
         end
-        @bytes_read += ret.size
-
-        #if @bytes_read > 5242880 # 5.megabytes
-        #  bytes = @bytes_read
-        #  @bytes_read = 0
-        #  raise Grit::Git::GitTimeout.new(command, bytes)
-        #end
 
         ret
       rescue Timeout::Error => e
-        bytes = @bytes_read
-        @bytes_read = 0
-        raise Grit::Git::GitTimeout.new(command, bytes)
+        raise Grit::Git::GitTimeout.new(command, ret.size)
       end
 
       def looking_for(commit, path = nil)

--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -52,12 +52,11 @@ module Grit
       Grit::Git.git_timeout = old_timeout
     end
 
-    attr_accessor :git_dir, :bytes_read, :work_tree
+    attr_accessor :git_dir, :work_tree
 
     def initialize(git_dir, work_tree = nil)
       self.git_dir    = git_dir
       self.work_tree  = work_tree
-      self.bytes_read = 0
     end
 
     def shell_escape(str)

--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -53,7 +53,7 @@ module Grit
         raise NoSuchPathError.new(epath)
       end
 
-      self.git = Git.new(self.path)
+      self.git = @bare ? Git.new(self.path) : Git.new(self.path, self.working_dir)
     end
 
     # Public: Initialize a git repository (create it on the filesystem). By

--- a/test/test_actor.rb
+++ b/test/test_actor.rb
@@ -7,10 +7,18 @@ class TestActor < Test::Unit::TestCase
 
   # output
   def test_output_adds_tz_offset
-    t = Time.now
+    # Mock time object which is in India Standard Time, at a UTC offset of
+    # +05:30.  We cannot construct a real time value with a given offset
+    # because Ruby's Time class can only represent local time or GMT.
+    t = stub(:to_i => 1234567, :utc_offset => 19800)
     a = Actor.new("Tom Werner", "tom@example.com")
-    assert_equal "Tom Werner <tom@example.com> #{t.to_i} -0700", 
+    assert_equal "Tom Werner <tom@example.com> #{t.to_i} +0530",
       a.output(t)
+
+    # Make sure negative offests work too
+    t = stub(:to_i => 1234567, :utc_offset => -19800)
+    assert_equal "Tom Werner <tom@example.com> #{t.to_i} -0530",
+      a.output(t)    
   end
 
   # from_string


### PR DESCRIPTION
I was working on a script that needed to manipulate the working tree of a Git repo. While Grit appeared to handle non-bare repos, it passed in the `--git-dir` parameter but never passed the `--work-tree` parameter to Git, causing it to do all working tree manipulations in the current working directory instead of the working tree of the repo it was supposed to work in. I've provided a patch that fixes that, which passes the working tree into the external Git command if working with a non-bare repo. 

This patch doesn't affect bare repos, and doesn't affect any usage which doesn't touch the working tree. All unit tests still pass with this patch. The patch does not include any new unit tests to test the new functionality, however, as it looked like more worth than I wanted to do to set up the testing infrastructure for that use case. Let me know if you need tests for this.

There are also a couple of cleanup patches here; one which fixed a unit test that failed when I ran it in my timezone (and also failed if I ran it against half-hour timezones), and one which removes some vestigial code.
