### PR TITLE
Memoize index

### DIFF
--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -625,7 +625,7 @@ module Grit
     end
 
     def index
-      Index.new(self)
+      @index ||= Index.new(self)
     end
 
     def update_ref(head, commit_sha)


### PR DESCRIPTION
Hello,

I had some problems when using something like:
@repo.index.read_tree('master)
@repo.index.add(...)

Because each time the .index method is called, a new Grit::Index is returned with an empty tree.

This commit memoizes this Index to @index
