### PR TITLE
Index#write_tree won't remove directories

### DIFF
--- a/lib/grit/index.rb
+++ b/lib/grit/index.rb
@@ -201,6 +201,7 @@ module Grit
             tree_contents[k + '/'] = str
           when false
             tree_contents.delete(k)
+            tree_contents.delete(k + '/')
         end
       end
 

--- a/test/test_rubygit_index.rb
+++ b/test/test_rubygit_index.rb
@@ -121,4 +121,19 @@ class TestRubyGitIndex < Test::Unit::TestCase
     b = @git.commits.first.tree/'README.txt'
     assert_equal 'e45d6b418e34951ddaa3e78e4fc4d3d92a46d3d1', b.id
   end
+
+  def test_delete_files
+    sha = @git.commits.first.tree.id
+
+    i = @git.index
+    i.read_tree(sha)
+    i.delete('README.txt')
+    i.delete('lib')
+    i.delete('test/fixtures')
+    i.commit('message', [@git.commits.first], @user, nil, 'master')
+
+    assert_nil @git.commits.first.tree/'README.txt'
+    assert_nil @git.commits.first.tree/'lib'
+    assert_nil @git.commits.first.tree/'test/fixtures'
+  end
 end


### PR DESCRIPTION
Working on [Silo](http://koraktor.de/silo) I stumbled upon `Grit::Index#write_tree` not removing directories when paths are not suffixed with a slash. Additionally `Grit::Index#add` will always strip a trailing slash due to `split('/')`. So you won't be able to delete a directory at all using `Grit::Index#delete`.

I think this is generally undesired as you're otherwise not required to suffix directory or tree paths with a slash.

I added two patches adding a test for that issue and also fixing the problem in `Index#write_tree`.
