### PR TITLE
Fixing delete of Grit::Tree

### DIFF
--- a/lib/grit/index.rb
+++ b/lib/grit/index.rb
@@ -176,7 +176,8 @@ module Grit
             str = "%s %s\0%s" % ['40000', k, sha]
             tree_contents[k + '/'] = str
           when false
-            tree_contents.delete(k)
+            deleted_file = tree_contents.delete(k)
+            tree_contents.delete(k + '/') unless deleted_file
         end
       end
 

--- a/test/test_rubygit_index.rb
+++ b/test/test_rubygit_index.rb
@@ -121,4 +121,22 @@ class TestRubyGitIndex < Test::Unit::TestCase
     b = @git.commits.first.tree/'README.txt'
     assert_equal 'e45d6b418e34951ddaa3e78e4fc4d3d92a46d3d1', b.id
   end
+
+  def test_delete_files
+    sha = @git.commits.first.tree.id
+
+    i = @git.index
+    i.read_tree(sha)
+    i.delete('README.txt')
+    i.delete('lib')
+    i.commit('message', [@git.commits.first], @user, nil, 'master')
+
+    b = @git.commits.first.tree/'README.txt'
+    assert_equal nil, b
+    b = @git.commits.first.tree/'lib'
+    assert_equal nil, b
+    assert_raise NoMethodError do
+      @git.commits.first.tree/'lib'/'grit.rb'
+    end
+  end
 end

--- a/test/test_rubygit_index.rb
+++ b/test/test_rubygit_index.rb
@@ -131,10 +131,8 @@ class TestRubyGitIndex < Test::Unit::TestCase
     i.delete('lib')
     i.commit('message', [@git.commits.first], @user, nil, 'master')
 
-    b = @git.commits.first.tree/'README.txt'
-    assert_equal nil, b
-    b = @git.commits.first.tree/'lib'
-    assert_equal nil, b
+    assert_nil @git.commits.first.tree/'README.txt'
+    assert_nil @git.commits.first.tree/'lib'
     assert_raise NoMethodError do
       @git.commits.first.tree/'lib'/'grit.rb'
     end


### PR DESCRIPTION
I have a repository with the next structure:

app
|-README.txt

I'm trying to delete entire folder content (as 'git rm -r app')

```
 sha = @repo.commits.first.tree.id
 index = @repo.index
 index.read_tree(sha)
 index.delete('app')
```

README.txt is deleted from index but 'app' is keep without content (contents method of this Grit::Tree returns []).

This patch delete the remainder Grit::Tree. Also I add tests for delete files/folder because I don't found where to put a test for this.
