### PR TITLE
Fixed order of GritRuby::Repository#rev_list

### DIFF
--- a/lib/grit/git-ruby/repository.rb
+++ b/lib/grit/git-ruby/repository.rb
@@ -304,11 +304,7 @@ module Grit
         end
 
         log = log(sha, options)
-        log = log.sort { |a, b| a[2] <=> b[2] }.reverse
-
-        if end_sha
-          log = truncate_arr(log, end_sha)
-        end
+        log = truncate_arr(log, end_sha) if end_sha
 
         # shorten the list if it's longer than max_count (had to get everything in branches)
         if options[:max_count]


### PR DESCRIPTION
For some reason the commits are sorted in `#rev_list`, causing `Grit::Commit.find_all` and `Grit::Repo#commits` being sorted to. Sorting doesn't make any sense, because commits should stay in their order.
