### PR TITLE
Default parameter for with_timeout incorrect

### DIFF
--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -73,7 +73,7 @@ module Grit
     self.git_timeout  = 10
     self.git_max_size = 5242880 # 5.megabytes
 
-    def self.with_timeout(timeout = 10.seconds)
+    def self.with_timeout(timeout = 10)
       old_timeout = Grit::Git.git_timeout
       Grit::Git.git_timeout = timeout
       yield

--- a/test/test_git.rb
+++ b/test/test_git.rb
@@ -64,6 +64,14 @@ class TestGit < Test::Unit::TestCase
     Grit::Git.git_timeout = 5.0
   end
 
+  def test_with_timeout_default_parameter
+    assert_nothing_raised do
+      Git::Git.with_timeout do
+        @git.version
+      end
+    end
+  end
+
   def test_it_really_shell_escapes_arguments_to_the_git_shell
     @git.expects(:sh).with("#{Git.git_binary} --git-dir='#{@git.git_dir}' foo --bar='bazz\\'er'")
     @git.run('', :foo, '', {:bar => "bazz'er"}, [])


### PR DESCRIPTION
It looks like the with_timeout method hasn't been touched for awhile, the default parameter is `10.seconds`, which obviously raises an error without ActiveSupport required. I made the smallest impact change which is to change the default parameter to 10, but I wonder if having a default parameter really makes sense for this method. The default timeout attribute is set to 10 as is and calling with_timeout without a parameter would do exactly the same as not calling the method at all. 

I have included a small test that is of little value but it validates the current error.
