### PR TITLE
Add Commit#patch_id

### DIFF
--- a/lib/grit/commit.rb
+++ b/lib/grit/commit.rb
@@ -252,6 +252,21 @@ module Grit
       ret
     end
 
+    # Calculates the commit's Patch ID. The Patch ID is essentially the SHA1
+    # of the diff that the commit is introducing.
+    #
+    # Returns the 40 character hex String if a patch-id could be calculated
+    #   or nil otherwise.
+    def patch_id
+      show = @repo.git.show({}, @id)
+      patch_line = @repo.git.native(:patch_id, :input => show)
+      if patch_line =~ /^([0-9a-f]{40}) [0-9a-f]{40}\n$/
+        $1
+      else
+        nil
+      end
+    end
+
     # Pretty object inspection
     def inspect
       %Q{#<Grit::Commit "#{@id}">}

--- a/test/test_commit.rb
+++ b/test/test_commit.rb
@@ -193,6 +193,13 @@ class TestCommit < Test::Unit::TestCase
     assert patch.include?("1.7.")
   end
 
+  # patch_id
+  
+  def test_patch_id
+    @c = Commit.create(@r, :id => '80f136f500dfdb8c3e8abf4ae716f875f0a1b57f')
+    assert_equal '9450b04e4f83ad0067199c9e9e338197d1835cbb', @c.patch_id
+  end
+
   # inspect
 
   def test_inspect


### PR DESCRIPTION
A method for calculating a commit's Patch ID. I'ma use this for CommitsSearch.
