### PR TITLE
Fix warnings on 1.9

### DIFF
--- a/lib/grit/commit.rb
+++ b/lib/grit/commit.rb
@@ -13,7 +13,6 @@ module Grit
     lazy_reader :committed_date
     lazy_reader :message
     lazy_reader :short_message
-    # lazy_reader :author_string
 
     # Parses output from the `git-cat-file --batch'.
     #

--- a/lib/grit/commit.rb
+++ b/lib/grit/commit.rb
@@ -13,7 +13,7 @@ module Grit
     lazy_reader :committed_date
     lazy_reader :message
     lazy_reader :short_message
-    lazy_reader :author_string
+    # lazy_reader :author_string
 
     # Parses output from the `git-cat-file --batch'.
     #

--- a/lib/grit/git-ruby/file_index.rb
+++ b/lib/grit/git-ruby/file_index.rb
@@ -28,8 +28,6 @@ module Grit
 
     self.max_file_size = 10_000_000 # ~10M
 
-    attr_reader :files
-
     # initializes index given repo_path
     def initialize(repo_path)
       @index_file = File.join(repo_path, 'file-index')

--- a/lib/grit/git-ruby/git_object.rb
+++ b/lib/grit/git-ruby/git_object.rb
@@ -290,7 +290,8 @@ module Grit
   end
 
   class Tag < GitObject
-    attr_accessor :object, :type, :tag, :tagger, :message
+    attr_accessor :object, :tag, :tagger, :message
+    attr_writer :type
 
     def self.from_raw(rawobject, repository=nil)
 

--- a/lib/grit/git-ruby/repository.rb
+++ b/lib/grit/git-ruby/repository.rb
@@ -475,60 +475,60 @@ module Grit
       #   [full_path, 'modified', tree1_hash, tree2_hash]
       #  ]
       def quick_diff(tree1, tree2, path = '.', recurse = true)
-         # handle empty trees
-         changed = []
-         return changed if tree1 == tree2
+        # handle empty trees
+        changed = []
+        return changed if tree1 == tree2
 
-         t1 = list_tree(tree1) if tree1
-         t2 = list_tree(tree2) if tree2
+        t1 = list_tree(tree1) if tree1
+        t2 = list_tree(tree2) if tree2
 
-         # finding files that are different
-         t1['blob'].each do |file, hsh|
-           t2_file = t2['blob'][file] rescue nil
-           full = File.join(path, file)
-           if !t2_file
-             changed << [full, 'added', hsh[:sha], nil]      # not in parent
-           elsif (hsh[:sha] != t2_file[:sha])
-             changed << [full, 'modified', hsh[:sha], t2_file[:sha]]   # file changed
-           end
-         end if t1
-         t2['blob'].each do |file, hsh|
-           if !t1 || !t1['blob'][file]
-             changed << [File.join(path, file), 'removed', nil, hsh[:sha]]
-           end
-         end if t2
+        # finding files that are different
+        t1['blob'].each do |file, hsh|
+          t2_file = t2['blob'][file] rescue nil
+          full = File.join(path, file)
+          if !t2_file
+            changed << [full, 'added', hsh[:sha], nil]      # not in parent
+          elsif (hsh[:sha] != t2_file[:sha])
+            changed << [full, 'modified', hsh[:sha], t2_file[:sha]]   # file changed
+          end
+        end if t1
+        t2['blob'].each do |file, hsh|
+          if !t1 || !t1['blob'][file]
+            changed << [File.join(path, file), 'removed', nil, hsh[:sha]]
+          end
+        end if t2
 
-         t1['tree'].each do |dir, hsh|
-           t2_tree = t2['tree'][dir] rescue nil
-           full = File.join(path, dir)
-           if !t2_tree
-             if recurse
-               changed += quick_diff(hsh[:sha], nil, full, true)
-             else
-               changed << [full, 'added', hsh[:sha], nil]      # not in parent
-             end
-           elsif (hsh[:sha] != t2_tree[:sha])
-             if recurse
-               changed += quick_diff(hsh[:sha], t2_tree[:sha], full, true)
-             else
-               changed << [full, 'modified', hsh[:sha], t2_tree[:sha]]   # file changed
-             end
-           end
-         end if t1
-         t2['tree'].each do |dir, hsh|
-           t1_tree = t1['tree'][dir] rescue nil
-           full = File.join(path, dir)
-           if !t1_tree
-             if recurse
-               changed += quick_diff(nil, hsh[:sha], full, true)
-             else
-               changed << [full, 'removed', nil, hsh[:sha]]
-             end
-           end
-         end if t2
+        t1['tree'].each do |dir, hsh|
+          t2_tree = t2['tree'][dir] rescue nil
+          full = File.join(path, dir)
+          if !t2_tree
+            if recurse
+              changed += quick_diff(hsh[:sha], nil, full, true)
+            else
+              changed << [full, 'added', hsh[:sha], nil]      # not in parent
+            end
+          elsif (hsh[:sha] != t2_tree[:sha])
+            if recurse
+              changed += quick_diff(hsh[:sha], t2_tree[:sha], full, true)
+            else
+              changed << [full, 'modified', hsh[:sha], t2_tree[:sha]]   # file changed
+            end
+          end
+        end if t1
+        t2['tree'].each do |dir, hsh|
+          t1_tree = t1['tree'][dir] rescue nil
+          full = File.join(path, dir)
+          if !t1_tree
+            if recurse
+              changed += quick_diff(nil, hsh[:sha], full, true)
+            else
+              changed << [full, 'removed', nil, hsh[:sha]]
+            end
+          end
+        end if t2
 
-         changed
-       end
+        changed
+      end
 
       # returns true if the files in path_limiter were changed, or no path limiter
       # used by the log() function when passed with a path_limiter
@@ -551,9 +551,9 @@ module Grit
 
         if path && !(path == '' || path == '.' || path == './')
           paths = path.split('/')
-          paths.each do |path|
+          paths.each do |pathname|
             tree = get_object_by_sha1(tree_sha)
-            if entry = tree.entry.select { |e| e.name == path }.first
+            if entry = tree.entry.select { |e| e.name == pathname }.first
               tree_sha = entry.sha1 rescue nil
             else
               return false
@@ -720,9 +720,9 @@ module Grit
           end
         end
 
-        def load_alternate_loose(path)
+        def load_alternate_loose(pathname)
           # load alternate loose, too
-          each_alternate_path path do |path|
+          each_alternate_path pathname do |path|
             next if @loaded.include?(path)
             next if !File.exist?(path)
             load_loose(path)
@@ -745,8 +745,8 @@ module Grit
           @packs
         end
 
-        def load_alternate_packs(path)
-          each_alternate_path path do |path|
+        def load_alternate_packs(pathname)
+          each_alternate_path pathname do |path|
             full_pack = File.join(path, 'pack')
             next if @loaded_packs.include?(full_pack)
             load_packs(full_pack)

--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -436,8 +436,8 @@ module Grit
       repo_refs       = self.git.rev_list({}, ref).strip.split("\n")
       other_repo_refs = other_repo.git.rev_list({}, other_ref).strip.split("\n")
 
-      (other_repo_refs - repo_refs).map do |ref|
-        Commit.find_all(other_repo, ref, {:max_count => 1}).first
+      (other_repo_refs - repo_refs).map do |refn|
+        Commit.find_all(other_repo, refn, {:max_count => 1}).first
       end
     end
 
@@ -491,7 +491,7 @@ module Grit
     end
 
     # quick way to get a simple array of hashes of the entries
-    # of a single tree or recursive tree listing from a given 
+    # of a single tree or recursive tree listing from a given
     # sha or reference
     #   +treeish+ is the reference (default 'master')
     #   +options+ is a hash or options - currently only takes :recursive


### PR DESCRIPTION
This commit fixes several warnings for running under 1.9. Ignoring dependencies:

```
~/code/grit[d4ed1eb...]% ruby -w -Ilib -rgrit -e ''                          
/Users/lee/code/grit/lib/grit/git-ruby/repository.rb:531: warning: mismatched indentations at 'end' with 'def' at 477
/Users/lee/code/grit/lib/grit/git-ruby/repository.rb:554: warning: shadowing outer local variable - path
/Users/lee/code/grit/lib/grit/git-ruby/repository.rb:725: warning: shadowing outer local variable - path
/Users/lee/code/grit/lib/grit/git-ruby/repository.rb:749: warning: shadowing outer local variable - path
/Users/lee/code/grit/lib/grit/git-ruby/git_object.rb:344: warning: method redefined; discarding old type
/Users/lee/code/grit/lib/grit/git-ruby/file_index.rb:83: warning: method redefined; discarding old files
/Users/lee/code/grit/lib/grit/commit.rb:285: warning: method redefined; discarding old author_string
/Users/lee/code/grit/lib/grit/lazy.rb:26: warning: previous definition of author_string was here
/Users/lee/code/grit/lib/grit/repo.rb:439: warning: shadowing outer local variable - ref
```

Now:

```
~/code/grit[master]% ruby -w -Ilib -rgrit -e ''
~/code/grit[master]%
```
