### PR TITLE
Fix the gemspec

### DIFF
--- a/grit.gemspec
+++ b/grit.gemspec
@@ -60,10 +60,8 @@ Gem::Specification.new do |s|
     lib/grit/git-ruby/repository.rb
     lib/grit/git.rb
     lib/grit/index.rb
-    lib/grit/jruby.rb
     lib/grit/lazy.rb
     lib/grit/merge.rb
-    lib/grit/process.rb
     lib/grit/ref.rb
     lib/grit/repo.rb
     lib/grit/ruby1.9.rb


### PR DESCRIPTION
Installing from the git repo with Bundler was impossible because two files from the gemspec were missing.
