### PR TITLE
Fix git executable search on windows.

### DIFF
--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -73,6 +73,11 @@ module Grit
           ENV['PATH'].split(':').
             map  { |p| File.join(p, 'git') }.
             find { |p| File.exist?(p) }
+        # Windows PATH search
+        @git_binary ||=
+          ENV['PATH'].split(';').
+            map  { |p| File.join(p, 'git.exe') }.
+            find { |p| File.exist?(p) }
       end
       attr_writer :git_binary
     end


### PR DESCRIPTION
Grit can't find git.exe on windows.
