### PR TITLE
Better count

### DIFF
--- a/lib/grit/commit.rb
+++ b/lib/grit/commit.rb
@@ -99,7 +99,7 @@ module Grit
     #
     # Returns Integer
     def self.count(repo, ref)
-      repo.git.rev_list({}, ref).size / 41
+      repo.git.rev_list({:all => true, :count => true, :timeout => false}, ref).to_i
     end
 
     # Find all commits matching the given criteria.


### PR DESCRIPTION
The previous count wastes too much resources on projects with a huge number of commits, while giving the right parameters to rev-list will do a better job for the count we need.
