### PR TITLE
Fix Repository#rev_list silently ignoring :since and :until when they're of a class other than Time

### DIFF
--- a/lib/grit/git-ruby/repository.rb
+++ b/lib/grit/git-ruby/repository.rb
@@ -343,10 +343,11 @@ module Grit
 
           add_sha = true
 
-          if opts[:since] && opts[:since].is_a?(Time) && (opts[:since] > c.committer.date)
+          if opts[:since] && (opts[:since] > c.committer.date)
             add_sha = false
           end
-          if opts[:until] && opts[:until].is_a?(Time) && (opts[:until] < c.committer.date)
+
+          if opts[:until] && (opts[:until] < c.committer.date)
             add_sha = false
           end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -20,3 +20,16 @@ end
 def jruby?
   defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /jruby/
 end
+
+# a class which can be compared to Time, but is not Time.
+class DuckTime
+  include Comparable
+
+  def initialize(time)
+    @time = time
+  end
+
+  def <=>(other)
+    @time <=> other
+  end
+end

--- a/test/test_rubygit.rb
+++ b/test/test_rubygit.rb
@@ -143,6 +143,12 @@ class TestRubyGit < Test::Unit::TestCase
     assert_match fixture('rev_list_since'), out  # I return slightly more for now
   end
 
+  def test_rev_list_raw_since_ducktype
+    since_time = @git.rev_list({:since => Time.at(1204644738)}, 'master')
+    since_duck = @git.rev_list({:since => DuckTime.new(Time.at(1204644738))}, 'master')
+    assert_equal since_time, since_duck
+  end
+
   def test_rev_list_pretty_raw
     out = @git.rev_list({:pretty => 'raw'}, 'f1964ad1919180dd1d9eae9d21a1a1f68ac60e77')
     assert_match 'f1964ad1919180dd1d9eae9d21a1a1f68ac60e77', out


### PR DESCRIPTION
Currently, the `:since` and `:until` arguments to `Grit::GitRuby::Repository#rev_list` must be `is_a?(Time)`, or they're silently ignored. This is confusing, so this patch simply removes the check and adds a test to verify that a `Time`-like object is accepted.
