### PR TITLE
Fixed Grit::Git#options_to_argv generates invalid sequence of arguments.

### DIFF
--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -378,7 +378,7 @@ module Grit
     # Returns an Array of String option arguments.
     def options_to_argv(options)
       argv = []
-      options.each do |key, val|
+      options.sort_by{|key, val| key.to_s.length}.each do |key, val|
         if key.to_s.size == 1
           if val == true
             argv << "-#{key}"


### PR DESCRIPTION
When mixed short-style option and long-style option, 
options_to_argv often generates invalid sequence of arguments.

  repo.git.branch(:merged => true, :a => true)

In this case, options_to_argv should generates "-a --merged", 
but "--merged -a".
Then it execute command like "git branch --merged -a", it will
happen 'fatal: malformed object name -a'.

Arguments that generated by options_to_argv should be sorted by option's
length.
For examples, "-a" option should be in front of "--no-merged" option.
