### PR TITLE
Use native cat-file instead of Grit::GitRuby#cat_file to get blob size

### DIFF
--- a/lib/grit/blob.rb
+++ b/lib/grit/blob.rb
@@ -33,7 +33,7 @@ module Grit
     #
     # Returns Integer
     def size
-      @size ||= @repo.git.cat_file({:s => true}, id).chomp.to_i
+      @size ||= @repo.git.native(:cat_file, { :s => true }, id).chomp.to_i
     end
 
     # The binary contents of this blob.


### PR DESCRIPTION
Using git's native cat-file is very often faster than using Grit::GitRuby#cat_file when getting blob sizes. It is also more memory efficient when dealing with large blobs.

```
Benchmark.bm do |x|
  tree.contents.each do |item|
    x.report("#{item.name} (native)") do
      5.times do
        repo = Grit::Repo.new('test.git')
        repo.git.native(:cat_file, { :s => true }, item.id).chomp.to_i
      end
    end
  end

  tree.contents.each do |item|
    x.report("#{item.name} (GitRuby)") do
      5.times do
        repo = Grit::Repo.new('test.git')
        repo.git.cat_file({:s => true}, item.id).chomp.to_i
      end
    end
  end
end
```

---

```
                       user     system      total        real
1GB.bin (native)   0.000000   0.010000   1.130000 (  1.154575)
1KB.bin (native)   0.000000   0.000000   0.010000 (  0.018181)
1MB.bin (native)   0.010000   0.000000   0.020000 (  0.018124)
1GB.bin (GitRuby) 26.770000  30.460000  57.230000 ( 57.150955)
1KB.bin (GitRuby)  0.000000   0.000000   0.000000 (  0.001413)
1MB.bin (GitRuby)  0.020000   0.010000   0.030000 (  0.031075)
```
