### PR TITLE
Fixing numstat parsing for cases where files have spaces in their filepath

### DIFF
--- a/lib/grit/commit_stats.rb
+++ b/lib/grit/commit_stats.rb
@@ -68,7 +68,7 @@ module Grit
 
         files = []
         while lines.first =~ /^([-\d]+)\s+([-\d]+)\s+(.+)/
-          (additions, deletions, filename) = lines.shift.split
+          (additions, deletions, filename) = lines.shift.split(/\t/, 3)
           additions = additions.to_i
           deletions = deletions.to_i
           total = additions + deletions

--- a/test/fixtures/log
+++ b/test/fixtures/log
@@ -4,8 +4,8 @@ Date:   Thu May 29 15:56:41 2008 -0700
 
     added examples
 
-13      0       examples/ex_add_commit.rb
-1       1       examples/ex_index.rb
+13      	0       	examples/ex_add_commit.rb
+1       	1       	examples/ex_index.rb
 
 commit 8f19810374686ad23dd63342b08d4ad1e65204c4
 Author: Scott Chacon <schacon@gmail.com>
@@ -13,11 +13,11 @@ Date:   Thu May 29 15:16:16 2008 -0700
 
     rewrote the index implementation to write in pure ruby, which both speeds things up and deals with content mu
 
-14      0       examples/ex_index.rb
-1       1       lib/grit/git-ruby.rb
-1       5       lib/grit/git-ruby/repository.rb
-31      12      lib/grit/index.rb
-2       2       lib/grit/ref.rb
+14      	0       	examples/ex_index.rb
+1       	1       	lib/grit/git-ruby.rb
+1       	5       	lib/grit/git-ruby/repository.rb
+31      	12      	lib/grit/index.rb
+2       	2       	lib/grit/ref.rb
 
 commit 28f28c504f3ebb647dadd5d504aaf8133aecadd9
 Author: Scott Chacon <schacon@gmail.com>
@@ -25,6 +25,6 @@ Date:   Thu May 29 11:33:09 2008 -0700
 
     added some simple write ops : add, remove, commit
 
-101     0       API.txt
-1       0       PURE_TODO
-129     0       benchmarks.rb
+101     	0       	API.txt
+1       	0       	PURE_TODO
+129     	0       	benchmarks.rb

--- a/test/test_rgit_spaces.rb
+++ b/test/test_rgit_spaces.rb
@@ -49,4 +49,12 @@ class TestGritSpaces < Test::Unit::TestCase
     names = tree.blobs.collect { |b| b.name }
     assert names.include?("an evil file with a trailing space "), "does not contain the trailing space named file"
   end
+
+  def test_commit_stats_with_file_paths_containing_spaces
+      commited_files = @repo.commit('2edb031f77340b65a897e8536ad75f7b7596a607').stats.files
+      file_with_leading_space = commited_files[0][0]
+      file_with_trailing_space = commited_files[1][0]
+      assert_equal " an evil file with a leading space", file_with_leading_space
+      assert_equal "an evil file with a trailing space ", file_with_trailing_space
+  end
 end


### PR DESCRIPTION
I've also fixed the fixture in "test/fixtures/log" because the added/deleted stats are separated by spaces there, although git outputs the numstat information separated by tabs, as you can see here:

https://github.com/git/git/blob/b91766295f2b873bbd4ef79c06de05aff27f8e12/diff.c#L1524
