### PR TITLE
Fixed bug with improper shifting in renamed diffs

### DIFF
--- a/lib/grit/diff.rb
+++ b/lib/grit/diff.rb
@@ -57,11 +57,14 @@ module Grit
         elsif lines.first =~ /^similarity index (\d+)\%/
           sim_index    = $1.to_i
           renamed_file = true
-          2.times { lines.shift } # shift away the 2 `rename from/to ...` lines
+          3.times { lines.shift } # shift away `similarity` and the 2 `rename from/to ...` lines
         end
 
-        m, a_blob, b_blob, b_mode = *lines.shift.match(%r{^index ([0-9A-Fa-f]+)\.\.([0-9A-Fa-f]+) ?(.+)?$})
-        b_mode.strip! if b_mode
+        a_blob, b_blob, b_mode = nil, nil, nil
+        unless lines.empty? || lines.first =~ /^diff --git/
+          m, a_blob, b_blob, b_mode = *lines.shift.match(%r{^index ([0-9A-Fa-f]+)\.\.([0-9A-Fa-f]+) ?(.+)?$})
+          b_mode.strip! if b_mode
+        end
 
         diff_lines = []
         while lines.first && lines.first !~ /^diff/

--- a/test/test_diff.rb
+++ b/test/test_diff.rb
@@ -13,6 +13,7 @@ class TestDiff < Test::Unit::TestCase
     diffs = Grit::Diff.list_from_string(@r, output)
     assert_equal 2,   diffs.size
     assert_equal 10,  diffs.first.diff.split("\n").size
+    assert_equal '-', diffs.first.diff[0]
     assert_nil        diffs.last.diff
   end
 
@@ -27,7 +28,7 @@ class TestDiff < Test::Unit::TestCase
     assert_equal 'MIT-LICENSE', diffs[0].b_path
     assert_equal 90,            diffs[0].similarity_index
     assert                      diffs[0].renamed_file
-    assert diffs[0].diff.size > 0
+    assert_equal '-',           diffs[0].diff[0]
 
     # updated file
     assert_equal 'README.md', diffs[1].a_path
@@ -35,11 +36,13 @@ class TestDiff < Test::Unit::TestCase
     assert                   !diffs[1].renamed_file
     assert                   !diffs[1].new_file
     assert                   !diffs[1].deleted_file
+    assert_equal '-',         diffs[0].diff[0]
 
     # deleted file
     assert_equal 'Rakefile', diffs[2].a_path
     assert_equal 'Rakefile', diffs[2].b_path
     assert                   diffs[2].deleted_file
+    assert_equal '-',         diffs[0].diff[0]
 
     # rename w/o update
     assert_equal 'PURE_TODO', diffs[3].a_path
@@ -52,5 +55,6 @@ class TestDiff < Test::Unit::TestCase
     assert_equal 'foobar', diffs[4].a_path
     assert_equal 'foobar', diffs[4].b_path
     assert                 diffs[4].new_file
+    assert_equal '-',         diffs[0].diff[0]
   end
 end


### PR DESCRIPTION
Commit Message

```
* Changed the number 2 to 3 when shifting the lines in a copied or
renamed diff. Made sure to add assertions to the diff tests to
check for '-' as the first character for every non-empty diff.
* Added a condition to check for empty diffs and skip if necessary.

Until now, a non 100% renamed file gives it's diff starting with the
line 'index ....' as opposed to '--- a/...' in case of other diffs.
This commit solved that issue.
```

I have found this bug while I have been using this to extract diff. All the extracted diffs contain '--- a/FILENAME' as their starting line except in the copied/renamed case. So, I debugged that, and here is the patch.
