### PR TITLE
Allow numeric option arguments

### DIFF
--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -379,7 +379,9 @@ module Grit
     def options_to_argv(options)
       argv = []
       options.each do |key, val|
-        if key.to_s.size == 1
+        if key.kind_of? Integer
+          argv << "-#{key}" if val == true
+        elsif key.to_s.size == 1
           if val == true
             argv << "-#{key}"
           elsif val == false


### PR DESCRIPTION
"git log" takes a numeric argument that limits how much history it
shows.  The argument needs to begin with a single dash, even when the
number itself is longer than one character.  That isn't possible
without this change (we need to output "-10" instead of "--10").
