### PR TITLE
Fixing the git binary detection

### DIFF
--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -76,7 +76,7 @@ module Grit
         @git_binary ||=
           ENV['PATH'].split(':').
             map  { |p| File.join(p, 'git') }.
-            find { |p| File.exist?(p) }
+            find { |p| File.file?(p) && File.executable?(p) }
       end
       attr_writer :git_binary
     end

--- a/test/fixtures/git_bin/b/git
+++ b/test/fixtures/git_bin/b/git
@@ -1,0 +1,1 @@
+# test file for git binary detection

--- a/test/test_git.rb
+++ b/test/test_git.rb
@@ -140,4 +140,18 @@ class TestGit < Test::Unit::TestCase
       @git.native(:bad, {:raise => true})
     end
   end
+
+  def test_git_binary_is_found_correctly
+    # Setting git_binary to nil so it is fetched
+    Grit::Git.git_binary = nil
+
+    paths       = %w(a b).map { |p| File.expand_path("../fixtures/git_bin/#{p}", __FILE__) }.join(':')
+    saved_path  = ENV['PATH']
+    ENV['PATH'] = [paths, ENV['PATH']].join(':')
+
+    assert_match %r(git_bin/b/git$), Grit::Git.git_binary
+
+    # Re-Setting the git_binary so other tests don't fail
+    ENV['PATH'] = saved_path and Grit::Git.git_binary = nil
+  end
 end


### PR DESCRIPTION
Hi,

I had a strange issue with gollum. It was trying to access some folder named git I have. I found that it was grit, trying to use it as the git command.

I ended up looking at grit's code and found the problem.
It was testing that the tested path existed but not if it was an executable file.

Is pull request is a fix addressing that specific issue. I added tests too (they're not very pretty, sorry).

Just a question, is it for compatibility reasons that you're not using %x(which git) ?

Have a good day !
