### PR TITLE
Ability to specify line range for git blame

### DIFF
--- a/lib/grit/git-ruby/internal/pack.rb
+++ b/lib/grit/git-ruby/internal/pack.rb
@@ -14,7 +14,7 @@ require 'grit/git-ruby/internal/raw_object'
 require 'grit/git-ruby/internal/file_window'
 
 PACK_SIGNATURE = "PACK"
-PACK_IDX_SIGNATURE = "\377tOc"
+PACK_IDX_SIGNATURE = [0xFF, 0x74, 0x4F, 0x63]
 
 module Grit
   module GitRuby
@@ -56,7 +56,7 @@ module Grit
           end
 
           # read header
-          sig = idxfile.read(4)
+          sig = idxfile.read(4).unpack("C*")
           ver = idxfile.read(4).unpack("N")[0]
 
           if sig == PACK_IDX_SIGNATURE

--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -201,8 +201,8 @@ module Grit
       self.git.fs_read('description').chomp
     end
 
-    def blame(file, commit = nil)
-      Blame.new(self, file, commit)
+    def blame(file, commit = nil, start_line = nil, end_line = nil)
+      Blame.new(self, file, commit, start_line, end_line)
     end
 
     # An array of Head objects representing the branch heads in

--- a/lib/grit/ruby1.9.rb
+++ b/lib/grit/ruby1.9.rb
@@ -1,5 +1,5 @@
 class String
-  if ((defined? RUBY_VERSION) && (RUBY_VERSION[0..2] == "1.9"))
+  if self.method_defined?(:ord)
     def getord(offset); self[offset].ord; end
   else
     alias :getord :[]

--- a/test/test_blame.rb
+++ b/test/test_blame.rb
@@ -29,4 +29,30 @@ class TestBlame < Test::Unit::TestCase
     assert_equal '46291865ba0f6e0c9818b11be799fe2db6964d56', line.commit.id
   end
 
+  def test_line_range_blame
+    commit = '2d3acf90f35989df8f262dc50beadc4ee3ae1560'
+    blame = @r.blame('lib/grit.rb', commit, 25, 26)
+    assert_equal 2, blame.lines.size
+    line = blame.lines[0]
+    assert_equal "require 'grit/diff'", line.line
+    assert_equal 25, line.lineno
+    assert_equal 16, line.oldlineno
+    assert_equal '46291865ba0f6e0c9818b11be799fe2db6964d56', line.commit.id
+    line = blame.lines[1]
+    assert_equal "require 'grit/config'", line.line
+    assert_equal 26, line.lineno
+    assert_equal 23, line.oldlineno
+    assert_equal 'f1964ad1919180dd1d9eae9d21a1a1f68ac60e77', line.commit.id
+  end
+
+  def test_single_line_blame
+    commit = '2d3acf90f35989df8f262dc50beadc4ee3ae1560'
+    blame = @r.blame('lib/grit.rb', commit, 25)
+    assert_equal 1, blame.lines.size
+    line = blame.lines[0]
+    assert_equal "require 'grit/diff'", line.line
+    assert_equal 25, line.lineno
+    assert_equal 16, line.oldlineno
+    assert_equal '46291865ba0f6e0c9818b11be799fe2db6964d56', line.commit.id
+  end
 end


### PR DESCRIPTION
Sometimes full git blame is not necessary (for example, when you want to check who changed a specific line, like for error reporting). I've added two params to repo.blame, so it's possible to narrow down amount of data processed:

``` ruby
# get blame for line 25
repo.blame('lib/grit.rb', '2d3acf90f35989df8f262dc50beadc4ee3ae1560', 25)
# get blame for lines 25-26
repo.blame('lib/grit.rb', '2d3acf90f35989df8f262dc50beadc4ee3ae1560', 25, 26)
```

PS. Tests included
