### PR TITLE
Faster tree parsing

### DIFF
--- a/lib/grit/git-ruby/git_object.rb
+++ b/lib/grit/git-ruby/git_object.rb
@@ -179,7 +179,7 @@ module Grit
     attr_accessor :entry
 
     def self.from_raw(rawobject, repository=nil)
-      entries = rawobject.content.scan(/(\d+) ([^\x00]*)\x00(.{20})/).map do |mode, file_name, raw_sha|
+      entries = rawobject.content.scan(/(\d+) ([^\x00]*)\x00(.{20})/m).map do |mode, file_name, raw_sha|
         DirectoryEntry.new(mode, file_name, raw_sha.unpack("H*").first)
       end
       new(entries, repository)

--- a/lib/grit/git-ruby/git_object.rb
+++ b/lib/grit/git-ruby/git_object.rb
@@ -114,10 +114,7 @@ module Grit
     S_IFGITLINK = 0160000
     attr_accessor :mode, :name, :sha1
     def initialize(mode, filename, sha1o)
-      @mode = 0
-      mode.each_byte do |i|
-        @mode = (@mode << 3) | (i-'0'.getord(0))
-      end
+      @mode = mode.to_i(8)
       @name = filename
       @sha1 = sha1o
       if ![S_IFLNK, S_IFDIR, S_IFREG, S_IFGITLINK].include?(@mode & S_IFMT)


### PR DESCRIPTION
This patch results in a significant speedup for workloads that involve parsing a lot of trees. It also reduces 29 lines of code down to 3.

There are two optimizations:
1. Eliminate a slow manual conversion from base10 string to base8 integer. This actually showed up as a hot spot while profiling.
2. Use a regex to parse the tree object itself, instead of doing byte-by-byte comparisons.
