### PR TITLE
StatusFile::ignored

### DIFF
--- a/lib/grit/status.rb
+++ b/lib/grit/status.rb
@@ -100,7 +100,7 @@ module Grit
           end
 
           # find modified in tree
-         diff_files.each do |path, data|
+          diff_files.each do |path, data|
             @files[path] ? @files[path].merge!(data) : @files[path] = data
           end
 

--- a/lib/grit/status.rb
+++ b/lib/grit/status.rb
@@ -162,7 +162,7 @@ module Grit
         # directories
         ignored_dirs = []
         @base.git.ls_files({:others => true, 
-                            :ignore => true, :directory => true,
+                            :ignored => true, :directory => true,
                             :"exclude-standard" => true}).
                   split("\n").each do |file|
           if File.directory?(File.join(wdir, file))

--- a/lib/grit/status.rb
+++ b/lib/grit/status.rb
@@ -57,7 +57,7 @@ module Grit
     end
 
     class StatusFile
-      attr_accessor :path, :type, :stage, :untracked
+      attr_accessor :path, :type, :stage, :untracked, :ignored
       attr_accessor :mode_index, :mode_repo
       attr_accessor :sha_index, :sha_repo
 
@@ -73,6 +73,7 @@ module Grit
         @sha_index = hash[:sha_index]
         @sha_repo = hash[:sha_repo]
         @untracked = hash[:untracked]
+        @ignored = !!hash[:ignored]
       end
 
       def blob(type = :index)

--- a/lib/grit/status.rb
+++ b/lib/grit/status.rb
@@ -73,7 +73,7 @@ module Grit
         @sha_index = hash[:sha_index]
         @sha_repo = hash[:sha_repo]
         @untracked = hash[:untracked]
-        @ignored = !!hash[:ignored]
+        @ignored = hash[:ignored]
       end
 
       def blob(type = :index)

--- a/test/fixtures/ls_files
+++ b/test/fixtures/ls_files
@@ -1,3 +1,4 @@
+100644 0b4eb9fbbcbfb5fb8c0c8160d83ef637c89553d9 0	lib/grit/repo.rb
 100644 ae0786b99fc23d5a227bcfb54f12252f109ce39f 0	test/helper.rb
 100644 9bd6016010e5ad9e787104e75ac2ab5ad7e04096 0	test/profile.rb
 100644 373baa48adf7da63ec6bddc4adfece673c8bc2ad 0	test/suite.rb

--- a/test/fixtures/ls_others
+++ b/test/fixtures/ls_others
@@ -1,0 +1,3 @@
+.DS_Store
+pkg/grit-2.4.1.gem
+ignored.txt

--- a/test/fixtures/ls_others
+++ b/test/fixtures/ls_others
@@ -1,3 +1,4 @@
 .DS_Store
 pkg/grit-2.4.1.gem
 ignored.txt
+lib/grit/added_class.rb

--- a/test/fixtures/ls_others_ignore
+++ b/test/fixtures/ls_others_ignore
@@ -1,0 +1,2 @@
+.DS_Store
+ignored.txt

--- a/test/fixtures/ls_others_ignore
+++ b/test/fixtures/ls_others_ignore
@@ -1,2 +1,3 @@
 .DS_Store
 ignored.txt
+pkg/

--- a/test/test_index_status.rb
+++ b/test/test_index_status.rb
@@ -32,7 +32,8 @@ class TestIndexStatus < Test::Unit::TestCase
                      with({:stage => true}).
                      returns(fixture('ls_files'))
     Git.any_instance.expects(:ls_files).
-                     with({:others => true, :ignore => true, :"exclude-standard" => true}).
+                     with({:others => true, :ignore => true, :directory => true,
+                           :"exclude-standard" => true}).
                      returns(fixture('ls_others_ignore'))
     Git.any_instance.expects(:ls_files).
                      with({:others => true}).
@@ -53,7 +54,7 @@ class TestIndexStatus < Test::Unit::TestCase
 
     stat = status['pkg/grit-2.4.1.gem']
     assert stat.untracked
-    #assert stat.ignored
+    assert stat.ignored
 
     stat = status['ignored.txt']
     assert stat.untracked

--- a/test/test_index_status.rb
+++ b/test/test_index_status.rb
@@ -34,7 +34,8 @@ class TestIndexStatus < Test::Unit::TestCase
     assert_equal stat.sha_repo, "71e930d551c413a123f43e35c632ea6ba3e3705e"
     assert_equal stat.mode_repo, "100644"
     assert_equal stat.type, "M"
-    assert_equal stat.ignored, false
+    assert_nil stat.untracked
+    assert_nil stat.ignored
   end
 
 

--- a/test/test_index_status.rb
+++ b/test/test_index_status.rb
@@ -32,7 +32,7 @@ class TestIndexStatus < Test::Unit::TestCase
                      with({:stage => true}).
                      returns(fixture('ls_files'))
     Git.any_instance.expects(:ls_files).
-                     with({:others => true, :ignore => true, :directory => true,
+                     with({:others => true, :ignored => true, :directory => true,
                            :"exclude-standard" => true}).
                      returns(fixture('ls_others_ignore'))
     Git.any_instance.expects(:ls_files).

--- a/test/test_index_status.rb
+++ b/test/test_index_status.rb
@@ -28,8 +28,15 @@ class TestIndexStatus < Test::Unit::TestCase
   def test_status
     Git.any_instance.expects(:diff_index).with({}, 'HEAD').returns(fixture('diff_index'))
     Git.any_instance.expects(:diff_files).returns(fixture('diff_files'))
-    Git.any_instance.expects(:ls_files).with({:stage => true}).returns(fixture('ls_files'))
-    Git.any_instance.expects(:ls_files).with({:others => true}).returns(fixture('ls_others'))
+    Git.any_instance.expects(:ls_files).
+                     with({:stage => true}).
+                     returns(fixture('ls_files'))
+    Git.any_instance.expects(:ls_files).
+                     with({:others => true, :ignore => true, :"exclude-standard" => true}).
+                     returns(fixture('ls_others_ignore'))
+    Git.any_instance.expects(:ls_files).
+                     with({:others => true}).
+                     returns(fixture('ls_others'))
 
     status = @r.status
 
@@ -46,9 +53,11 @@ class TestIndexStatus < Test::Unit::TestCase
 
     stat = status['pkg/grit-2.4.1.gem']
     assert stat.untracked
+    #assert stat.ignored
 
     stat = status['ignored.txt']
     assert stat.untracked
+    assert stat.ignored
 
     stat = status['.DS_Store']
     assert_nil stat

--- a/test/test_index_status.rb
+++ b/test/test_index_status.rb
@@ -29,13 +29,21 @@ class TestIndexStatus < Test::Unit::TestCase
     Git.any_instance.expects(:diff_index).with({}, 'HEAD').returns(fixture('diff_index'))
     Git.any_instance.expects(:diff_files).returns(fixture('diff_files'))
     Git.any_instance.expects(:ls_files).with({:stage => true}).returns(fixture('ls_files'))
+    Dir.expects(:glob).with("**/*").yields(*%w{pkg/grit-2.4.1.gem})
     status = @r.status
+
     stat = status['lib/grit/repo.rb']
     assert_equal stat.sha_repo, "71e930d551c413a123f43e35c632ea6ba3e3705e"
     assert_equal stat.mode_repo, "100644"
     assert_equal stat.type, "M"
     assert_nil stat.untracked
     assert_nil stat.ignored
+
+    stat = status['pkg/grit-2.4.1.gem']
+    assert stat.untracked
+
+    stat = status['.DS_Store']
+    assert_nil stat
   end
 
 

--- a/test/test_index_status.rb
+++ b/test/test_index_status.rb
@@ -48,6 +48,9 @@ class TestIndexStatus < Test::Unit::TestCase
 
     stat = status['.DS_Store']
     assert_nil stat
+
+    stat = status['pkg']
+    assert_nil stat
   end
 
 

--- a/test/test_index_status.rb
+++ b/test/test_index_status.rb
@@ -29,8 +29,13 @@ class TestIndexStatus < Test::Unit::TestCase
     Git.any_instance.expects(:diff_index).with({}, 'HEAD').returns(fixture('diff_index'))
     Git.any_instance.expects(:diff_files).returns(fixture('diff_files'))
     Git.any_instance.expects(:ls_files).with({:stage => true}).returns(fixture('ls_files'))
-    Dir.expects(:glob).with("**/*").
-                       multiple_yields("pkg/grit-2.4.1.gem", "ignored.txt")
+    Dir.expects(:glob).with("**/*").multiple_yields("lib/grit/repo.rb", 
+                                                    "pkg",
+                                                    "pkg/grit-2.4.1.gem", 
+                                                    "ignored.txt")
+    File.expects(:directory?).with("pkg").returns(true)
+    File.expects(:directory?).with("pkg/grit-2.4.1.gem").returns(false)
+    File.expects(:directory?).with("ignored.txt").returns(false)
     status = @r.status
 
     stat = status['lib/grit/repo.rb']

--- a/test/test_index_status.rb
+++ b/test/test_index_status.rb
@@ -40,6 +40,10 @@ class TestIndexStatus < Test::Unit::TestCase
     assert_nil stat.untracked
     assert_nil stat.ignored
 
+    stat = status['lib/grit/added_class.rb']
+    assert stat.untracked
+    assert_nil stat.ignored
+
     stat = status['pkg/grit-2.4.1.gem']
     assert stat.untracked
 

--- a/test/test_index_status.rb
+++ b/test/test_index_status.rb
@@ -29,13 +29,8 @@ class TestIndexStatus < Test::Unit::TestCase
     Git.any_instance.expects(:diff_index).with({}, 'HEAD').returns(fixture('diff_index'))
     Git.any_instance.expects(:diff_files).returns(fixture('diff_files'))
     Git.any_instance.expects(:ls_files).with({:stage => true}).returns(fixture('ls_files'))
-    Dir.expects(:glob).with("**/*").multiple_yields("lib/grit/repo.rb", 
-                                                    "pkg",
-                                                    "pkg/grit-2.4.1.gem", 
-                                                    "ignored.txt")
-    File.expects(:directory?).with("pkg").returns(true)
-    File.expects(:directory?).with("pkg/grit-2.4.1.gem").returns(false)
-    File.expects(:directory?).with("ignored.txt").returns(false)
+    Git.any_instance.expects(:ls_files).with({:others => true}).returns(fixture('ls_others'))
+
     status = @r.status
 
     stat = status['lib/grit/repo.rb']

--- a/test/test_index_status.rb
+++ b/test/test_index_status.rb
@@ -34,6 +34,7 @@ class TestIndexStatus < Test::Unit::TestCase
     assert_equal stat.sha_repo, "71e930d551c413a123f43e35c632ea6ba3e3705e"
     assert_equal stat.mode_repo, "100644"
     assert_equal stat.type, "M"
+    assert_equal stat.ignored, false
   end
 
 

--- a/test/test_index_status.rb
+++ b/test/test_index_status.rb
@@ -29,7 +29,8 @@ class TestIndexStatus < Test::Unit::TestCase
     Git.any_instance.expects(:diff_index).with({}, 'HEAD').returns(fixture('diff_index'))
     Git.any_instance.expects(:diff_files).returns(fixture('diff_files'))
     Git.any_instance.expects(:ls_files).with({:stage => true}).returns(fixture('ls_files'))
-    Dir.expects(:glob).with("**/*").yields(*%w{pkg/grit-2.4.1.gem})
+    Dir.expects(:glob).with("**/*").
+                       multiple_yields("pkg/grit-2.4.1.gem", "ignored.txt")
     status = @r.status
 
     stat = status['lib/grit/repo.rb']
@@ -40,6 +41,9 @@ class TestIndexStatus < Test::Unit::TestCase
     assert_nil stat.ignored
 
     stat = status['pkg/grit-2.4.1.gem']
+    assert stat.untracked
+
+    stat = status['ignored.txt']
     assert stat.untracked
 
     stat = status['.DS_Store']


### PR DESCRIPTION
Hi,

Here is a patch proposal to add StatusFile::ignored. The aim is to distinguish between untracked files that are ignored from those that are not. 

Grit::Repo.status currently returns (mojombo/grit master branch as well as v2.4.1):
1) All tracked files, with flags according to their respective status 'M', 'A', 'D', etc.
2) All untracked files through a Dir.glob('*_/_'), except directories and hidden files (e.g., .DS_Store). This means that ignored files are returned by status (e.g. pkg/grit-2.4.1.gem)

The proposed patch preserves this behavior for backward compatibility. In addition, it sets StatusFile::ignored to true for files ignored by git. The implementation relies on some hacks around 'git ls-files --others'.

What do you think? About the StatusFile::ignored proposal? The backward compatibility behavior? The implementation?

P.S. I've recreated this pull request from a specific ignored branch in my repo. Sorry for the inconvenience.

Thanks!
