### PR TITLE
added correct location detection for win32 git binary

### DIFF
--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -73,10 +73,17 @@ module Grit
     class << self
       attr_accessor :git_timeout, :git_max_size
       def git_binary
-        @git_binary ||=
+        if RUBY_PLATFORM.downcase =~ /mswin(?!ce)|mingw|bccwin/
+          @git_binary ||=
+          ENV['PATH'].split(';').
+          map  { |p| File.join(p, 'git.exe') }.
+          find { |p| File.exist?(p) }
+        else
+          @git_binary ||=
           ENV['PATH'].split(':').
-            map  { |p| File.join(p, 'git') }.
-            find { |p| File.exist?(p) }
+          map  { |p| File.join(p, 'git') }.
+          find { |p| File.exist?(p) }
+        end
       end
       attr_writer :git_binary
     end


### PR DESCRIPTION
This patch adds code for checking which platform ruby is running on and figures out where the git binary is located even if the platform happens to be mingw32 on windows.

Code is only manually tested, unfortunately, and only works in a mingw32 shell.

However, those other shells didn't work on windows before this anyway... on my machine at least.
