### PR TITLE
Fixed Grit::Repo#diff to show diff for commits to unicode file names

### DIFF
--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -553,8 +553,8 @@ module Grit
     def diff(a, b, *paths)
       diff = self.git.native('diff', {}, a, b, '--', *paths)
 
-      if diff =~ /diff --git a/
-        diff = diff.sub(/.*?(diff --git a)/m, '\1')
+      if diff =~ /diff --git \"?a/
+        diff = diff.sub(/.*?(diff --git \"?a)/m, '\1')
       else
         diff = ''
       end


### PR DESCRIPTION
I had a file in my repo that had a unicode file name. 

repo.diff(commit1, commit2) was always returning [].

The problems was that the regex in Grit::Repo only match diffs with /diff --git a/, not /diff --git \"a/ .
