### PR TITLE
Whitespaces in filenames lead to truncated names in commit stats

### DIFF
--- a/lib/grit/commit_stats.rb
+++ b/lib/grit/commit_stats.rb
@@ -68,7 +68,7 @@ module Grit
 
         files = []
         while lines.first =~ /^([-\d]+)\s+([-\d]+)\s+(.+)/
-          (additions, deletions, filename) = lines.shift.split
+          (additions, deletions, filename) = lines.shift.split(nil, 3)
           additions = additions.to_i
           deletions = deletions.to_i
           total = additions + deletions


### PR DESCRIPTION
Having a filename with some whitespaces leads to inconsistent commit stats, as the git output line is being split completely by all whitespaces.

Can be fixed by limiting the desired output array length by 3. 
(so that the remaining whitespaces stay in the filename)
