### PR TITLE
support large packfiles with index v2

### DIFF
--- a/lib/grit/git-ruby/internal/pack.rb
+++ b/lib/grit/git-ruby/internal/pack.rb
@@ -30,6 +30,7 @@ module Grit
         SHA1Size = 20
         IdxOffsetSize = 4
         OffsetSize = 4
+        ExtendedOffsetSize = 8
         CrcSize = 4
         OffsetStart = FanOutCount * IdxOffsetSize
         SHA1Start = OffsetStart + OffsetSize
@@ -214,6 +215,12 @@ module Grit
               else
                 pos = OffsetStart + (@size * (SHA1Size + CrcSize)) + (mid * OffsetSize)
                 offset = idx[pos, OffsetSize].unpack('N')[0]
+                if offset & 0x80000000 > 0
+                  offset &= 0x7fffffff
+                  pos = OffsetStart + (@size * (SHA1Size + CrcSize + OffsetSize)) + (offset * ExtendedOffsetSize)
+                  words = idx[pos, ExtendedOffsetSize].unpack('NN')
+                  offset = (words[0] << 32) | words[1]
+                end
                 return offset
               end
             else


### PR DESCRIPTION
Grit has known about the "v2" pack index format for a while.
However, it never actually handled the extended offsets that
we get when indexing packfiles that are larger than 2
gigabytes.

When an object is at an offset smaller than 2G, its byte
offset into the packfile is placed in the first table of
4-byte offset values. If it's past that, then the MSB is set
on its offset in the 4-byte table, and the rest of the
4-byte integer specifies an offset into an 8-byte table that
follows.

With this patch, grit should handle arbitrarily large packs
(limited only by the pack format itself).

A few notes on the patch itself:
- I unpack using two "N" formats instead of "Q>", because
  "Q>" is not available in ruby < 1.9.3
- No automated test is included, because you need a
  packfile that is greater than 2G. I did test it by hand.
