### PR TITLE
Make grit compatible with git projects using the gitfile repository format

### DIFF
--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -44,6 +44,9 @@ module Grit
       if File.exist?(git_dir_or_file)
         if File.file?(git_dir_or_file)
           self.path = parse_gitfile(git_dir_or_file)
+          if self.path && self.path !~ %r[^/]
+            self.path = File.join(epath, self.path)
+          end
         else
           self.path = git_dir_or_file
         end

--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -39,10 +39,18 @@ module Grit
     # Raises Grit::NoSuchPathError if the path does not exist.
     def initialize(path, options = {})
       epath = File.expand_path(path)
+      git_dir_or_file = File.join(epath, '.git')
 
-      if File.exist?(File.join(epath, '.git'))
+      if File.exist?(git_dir_or_file)
+        if File.file?(git_dir_or_file)
+          self.path = parse_gitfile(git_dir_or_file)
+        else
+          self.path = git_dir_or_file
+        end
+        unless self.path && File.directory?(self.path)
+          raise InvalidGitRepositoryError.new(epath)
+        end
         self.working_dir = epath
-        self.path = File.join(epath, '.git')
         @bare = false
       elsif File.exist?(epath) && (epath =~ /\.git$/ || options[:is_bare])
         self.path = epath
@@ -703,6 +711,20 @@ module Grit
     # Pretty object inspection
     def inspect
       %Q{#<Grit::Repo "#{@path}">}
+    end
+
+    private
+
+    # Parse a gitfile (an ASCII file containing the line
+    # "gitdir: <path-to-gitdir>"). See 'man gitrepository-layout' for more
+    # information.
+    def parse_gitfile(path)
+      return nil unless File.file? path
+      pointer_line = File.read(path).split("\n")[0]
+      return nil unless pointer_line
+      matches = pointer_line.match /^gitdir: (.*)$/
+      return nil unless matches && matches.size == 2
+      matches[1]
     end
   end # Repo
 

--- a/test/test_repo.rb
+++ b/test/test_repo.rb
@@ -78,9 +78,18 @@ class TestRepo < Test::Unit::TestCase
     end
   end
 
-  def test_new_with_gitfile
+  def test_new_with_absolute_gitfile
     dot_git_path = File.expand_path(File.join(File.dirname(__FILE__), "dot_git"))
     with_new_gitfile_repo("gitdir: #{dot_git_path}") do |repo_path|
+      repo = Repo.new repo_path
+      assert_equal "ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a", repo.commits.first.id
+    end
+  end
+
+  def test_new_with_relative_gitfile
+    absolute_dot_git_path = File.expand_path(File.join(File.dirname(__FILE__), "dot_git"))
+    relative_dot_git_path = File.join("../..", absolute_dot_git_path)
+    with_new_gitfile_repo("gitdir: #{relative_dot_git_path}") do |repo_path|
       repo = Repo.new repo_path
       assert_equal "ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a", repo.commits.first.id
     end


### PR DESCRIPTION
This format has been used for git submodules as of 1.7.8.

See 'man gitrepository-layout' for more information.

Feel free to ignore this request if you don't care about compatibility with git 1.7.8+ (the README specifies that the tests run against 1.7.2.1).
