### PR TITLE
Make Grit::Status ignore submodule-contained files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ task :coverage do
   sh "open coverage/index.html"
 end
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title = "#{name} #{version}"

--- a/lib/grit/status.rb
+++ b/lib/grit/status.rb
@@ -89,12 +89,13 @@ module Grit
 
       def construct_status
         @files = ls_files
+        submodules = @files.values.select{ |file| file[:mode_index] == '160000' }.map!{ |file| file[:path] }
 
         Dir.chdir(@base.working_dir) do
           # find untracked in working dir
           Dir.glob('**/*') do |file|
-            if !@files[file]
-              @files[file] = {:path => file, :untracked => true} if !File.directory?(file)
+            if !@files[file] && !File.directory?(file) && submodules.select{ |path| file.start_with?(path) }.empty?
+              @files[file] = {:path => file, :untracked => true}
             end
           end
 

--- a/test/test_git.rb
+++ b/test/test_git.rb
@@ -10,7 +10,7 @@ class TestGit < Test::Unit::TestCase
   end
 
   def test_method_missing
-    assert_match(/^git version [\w\.]*$/, @git.version)
+    assert_match(/^git version [\w\.]*(?: \([^\)]+\))?$/, @git.version)
   end
 
   def test_logs_stderr


### PR DESCRIPTION
Submodule files were showing as untracked in the Grit::Status, which is a bit of a problem (to me at least).
Next is probably going to be taking ignored files out (or flagging them appropriately).

I also took the opportunity to fix one test case that was failing on Xcode-provided git binaries, because they include a custom version tag, e.g. my git's git --version reads "git version 1.7.7.5 (Apple Git-26)"
