### PR TITLE
Grit::Actor#== method for testing equality.

### DIFF
--- a/lib/grit/actor.rb
+++ b/lib/grit/actor.rb
@@ -47,6 +47,13 @@ module Grit
     def inspect
       %Q{#<Grit::Actor "#{@name} <#{@email}>">}
     end
+
+    # Equality
+    def ==(other)
+      other.class == self.class &&
+        other.name == name &&
+        other.email == email
+    end
   end # Actor
 
 end # Grit

--- a/test/test_actor.rb
+++ b/test/test_actor.rb
@@ -43,4 +43,25 @@ class TestActor < Test::Unit::TestCase
     a = Actor.from_string("Tom Werner <tom@example.com>")
     assert_equal a.name, a.to_s
   end
+
+  # equality
+
+  def test_equality
+    a = Actor.from_string("Tom Werner <tom@example.com>")
+    assert_equal a, a.dup
+  end
+
+  def test_inequality
+    assert_not_equal(
+      Actor.from_string("Tom Werner <tom@example.com>"),
+      Actor.from_string("Paul Annesley <paul@example.org>")
+    )
+  end
+
+  def test_inequality_due_to_class
+    assert_not_equal(
+      Actor.from_string("Tom Werner <tom@example.com>"),
+      Struct.new(:name, :email).new("Tom Werner", "tom@example.com")
+    )
+  end
 end


### PR DESCRIPTION
With unit tests, of course.

Uncovered by an application testing that for a standard commit, `c.committer == c.author`, which was incorrectly failing.

Cheers,
Paul
