### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - 1.9.3
+  - ree
+  - jruby-18mode
+  - jruby-19mode
+  - rbx-18mode
+  - rbx-19mode
+matrix:
+  allow_failures:
+    # JRuby does not support C extensions on Travis
+    - { rvm: jruby-18mode }
+    - { rvm: jruby-19mode }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Grit
 ====
 
+[![Build Status](https://secure.travis-ci.org/mojombo/grit.png?branch=master)](http://travis-ci.org/mojombo/grit)
+[![Dependency Status](https://gemnasium.com/mojombo/grit.png)](https://gemnasium.com/mojombo/grit)
+
 Grit gives you object oriented read/write access to Git repositories via Ruby.
 The main goals are stability and performance. To this end, some of the
 interactions with Git repositories are done by shelling out to the system's


### PR DESCRIPTION
- Add plenty of Ruby flavors to build with on Travis
  
  It doesn't build successfully with JRuby (yet), so we ignore build
  failures with JRuby for now.
- Add Travis and Gemnasium badges

Build is green: http://travis-ci.org/#!/joliss/grit
Don't forget to enable the build on http://travis-ci.org/profile
