### PR TITLE
More efficient counting of tags/remotes/heads 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+branches:
+  only:
+    - 'master'
+rvm:
+  - 1.9.2
+script: "rake test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ branches:
     - 'master'
 rvm:
   - 1.9.2
-script: "rake test"
+script: "bundle exec rake test"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source "http://rubygems.org"
+
+group :development, :test do
+  gem 'rake'
+  gem 'posix-spawn', "~> 0.3.6"
+  gem 'mime-types', "~> 1.15"
+  gem 'diff-lcs', "~> 1.1"
+  gem 'mocha'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,20 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.1.3)
+    metaclass (0.0.1)
+    mime-types (1.18)
+    mocha (0.11.4)
+      metaclass (~> 0.0.1)
+    posix-spawn (0.3.6)
+    rake (0.9.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  diff-lcs (~> 1.1)
+  mime-types (~> 1.15)
+  mocha
+  posix-spawn (~> 0.3.6)
+  rake

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Grit
+Grit [![build status](https://secure.travis-ci.org/gitlabhq/grit.png)](https://secure.travis-ci.org/gitlabhq/grit)
 ====
+
+
 
 Grit gives you object oriented read/write access to Git repositories via Ruby.
 The main goals are stability and performance. To this end, some of the

--- a/lib/grit/commit.rb
+++ b/lib/grit/commit.rb
@@ -142,6 +142,12 @@ module Grit
       commits = []
 
       while !lines.empty?
+        # GITLAB patch
+        # Skip all garbage unless we get real commit
+        while !lines.empty? && lines.first !~ /^commit [a-zA-Z0-9]*$/
+          lines.shift 
+        end
+
         id = lines.shift.split.last
         tree = lines.shift.split.last
 
@@ -158,6 +164,10 @@ module Grit
 
         # not doing anything with this yet, but it's sometimes there
         encoding = lines.shift.split.last if lines.first =~ /^encoding/
+
+        # GITLAB patch
+        # Skip Signature and other raw data
+        lines.shift while lines.first =~ /^ /
 
         lines.shift
 

--- a/lib/grit/ref.rb
+++ b/lib/grit/ref.rb
@@ -23,8 +23,7 @@ module Grit
         refs = repo.git.refs(options, prefix)
         refs.split("\n").map do |ref|
           name, id = *ref.split(' ')
-          commit = Commit.create(repo, :id => id)
-          self.new(name, commit)
+          self.new(name, repo, id)
         end
       end
 
@@ -37,22 +36,34 @@ module Grit
     end
 
     attr_reader :name
-    attr_reader :commit
 
     # Instantiate a new Head
     #   +name+ is the name of the head
     #   +commit+ is the Commit that the head points to
     #
     # Returns Grit::Head (baked)
-    def initialize(name, commit)
+    def initialize(name, repo, commit_id)
       @name = name
-      @commit = commit
+      @commit_id = commit_id
+      @repo_ref = repo
+      @commit = nil
+    end
+
+    def commit
+      @commit ||= get_commit
     end
 
     # Pretty object inspection
     def inspect
       %Q{#<#{self.class.name} "#{@name}">}
     end
+
+    protected
+
+    def get_commit
+      Commit.create(@repo_ref, :id => @commit_id)
+    end
+
   end # Ref
 
   # A Head is a named reference to a Commit. Every Head instance contains a name
@@ -74,8 +85,7 @@ module Grit
       head = repo.git.fs_read('HEAD').chomp
       if /ref: refs\/heads\/(.*)/.match(head)
         id = repo.git.rev_parse(options, 'HEAD')
-        commit = Commit.create(repo, :id => id)
-        self.new($1, commit)
+        self.new($1, repo, id)
       end
     end
 

--- a/lib/grit/ref.rb
+++ b/lib/grit/ref.rb
@@ -4,6 +4,16 @@ module Grit
 
     class << self
 
+      # Count all Refs
+      #   +repo+ is the Repo
+      #   +options+ is a Hash of options
+      #
+      # Returns int
+      def count_all(repo, options = {})
+        refs = repo.git.refs(options, prefix)
+        refs.split("\n").size
+      end
+
       # Find all Refs
       #   +repo+ is the Repo
       #   +options+ is a Hash of options

--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -213,6 +213,10 @@ module Grit
       Head.find_all(self)
     end
 
+    def head_count
+      Head.count_all(self)
+    end
+
     alias_method :branches, :heads
 
     def get_head(head_name)
@@ -278,6 +282,10 @@ module Grit
       Tag.find_all(self)
     end
 
+    def tag_count
+      Tag.count_all(self)
+    end
+
     # Finds the most recent annotated tag name that is reachable from a commit.
     #
     #   @repo.recent_tag_name('master')
@@ -308,6 +316,10 @@ module Grit
     # Returns Grit::Remote[] (baked)
     def remotes
       Remote.find_all(self)
+    end
+
+    def remote_count
+      Remote.count_all(self)
     end
 
     def remote_list

--- a/lib/grit/repo.rb
+++ b/lib/grit/repo.rb
@@ -218,6 +218,7 @@ module Grit
     end
 
     alias_method :branches, :heads
+    alias_method :branch_count, :head_count
 
     def get_head(head_name)
       heads.find { |h| h.name == head_name }

--- a/lib/grit/tag.rb
+++ b/lib/grit/tag.rb
@@ -7,17 +7,6 @@ module Grit
     lazy_reader :tagger
     lazy_reader :tag_date
 
-    def self.find_all(repo, options = {})
-      refs = repo.git.refs(options, prefix)
-      refs.split("\n").map do |ref|
-        name, id = *ref.split(' ')
-        sha = repo.git.commit_from_sha(id)
-        raise "Unknown object type." if sha == ''
-        commit = Commit.create(repo, :id => sha)
-        new(name, commit)
-      end
-    end
-
     # Writes a new tag object from a hash
     #  +repo+ is a Grit repo
     #  +hash+ is the hash of tag values
@@ -96,6 +85,12 @@ module Grit
         @tag_date = parsed[:tag_date]
       end
       self
+    end
+
+    def get_commit
+      sha = @repo_ref.git.commit_from_sha(@commit_id)
+      raise "Unknown object type." if sha == ''
+      Commit.create(@repo_ref, :id => sha)
     end
   end
 

--- a/test/test_commit_parse.rb
+++ b/test/test_commit_parse.rb
@@ -1,0 +1,77 @@
+require File.dirname(__FILE__) + '/helper'
+
+class TestCommitParse < Test::Unit::TestCase
+  def setup
+@output = %Q{
+commit 36a1987cd891fa82d9981886c3abbbe82c428c0d
+tree 26f2c1ebc2d0485de222f13ebf812456ee8a7cb8
+parent 31ae98359d26ff89b745c4f8094093cbf6ccbdc6
+parent 0d9f4f135eb6dea06bdcb7065b1e4ff78274a5e9
+author Linus Torvalds <torvalds@linux-foundation.org> 1337273075 -0700
+committer Linus Torvalds <torvalds@linux-foundation.org> 1337273075 -0700
+mergetag object 0d9f4f135eb6dea06bdcb7065b1e4ff78274a5e9
+ type commit
+ tag md-3.4-fixes
+ tagger NeilBrown <neilb@suse.de> 1337229653 +1000
+ 
+ md: 2 fixes for 3.4
+ tagger NeilBrown <neilb@suse.de> 1337229653 +1000
+ 
+ md: 2 fixes for 3.4
+ 
+ one fixes a bug in the new raid10 resize code so is relevant
+ to 3.4 only
+ Other fixes a bug in the use of md by dm-raid, so is relevant
+ to any kernel with dm-raid support
+ -----BEGIN PGP SIGNATURE-----
+ Version: GnuPG v2.0.18 (GNU/Linux)
+ 
+ iQIVAwUAT7SBkznsnt1WYoG5AQK3wQ//Q2sPicPHb5MNGTTBpphYo1QWo+l9jFHs
+ ZDBM+MaiNJg3kBN5ueUU+MENvLcaA5+zoxsGVBXBKyXr70ffqiQcLXyU7fHwrGu3
+ 5MD36p55ZPnq2pemCrp4qdTXEUabmDb+0/R7e5lywnzNdbmCAfh4uYih0VPiaClV
+ ihq/Ci12TDnezmLjksc09OCquhm0s3zH2BnMCVdmSAkhnXCxTeZ45s/ob71Y2xvj
+ cJ15SYlAG4t0QCikL5R8pZtkh0h2SuUhufDE09eD8yT4RGO4PHSQ4oHujajftzey
+ 9sB0NGH7Yla8gOXjA+EpzKPaiqtZxJB+1v/bhqA2FoOYAks8VoFfeqgwUbPYE7bk
+ GIfGB4hFsUXaJo13uzofyJXBIp9mM/J5Sk1VJsiLE85P7wewg6N199B8lpC3lFDw
+ tMLjfTMJzFOUqZBESjJoxyrc4fairZ9VCUWwpqjuioLO50e+lOi/jQHTspX78e+w
+ GxgjHp8hh0RqQiTkl7vIz9KVcQIeOTG9uzz61IuDp15cRSrMs6E8gVKoX8gKW9g2
+ Hec17fdG/H6ZeZa7MB9GzUD4HCj0PRbODQ3/fPhUdsbgtQjOvsVUH8LCRRU0U6cb
+ YF+qsDFtUF7QT2kNbrs9R6adGj97c2HWUMyRWMQAXGuL5TkstvhrRv/rk1+bv2VG
+ w7ptbiklj7o=
+ =9zxe
+ -----END PGP SIGNATURE-----
+
+    Merge tag 'md-3.4-fixes' of git://neil.brown.name/md
+    
+    Pull two md fixes from NeilBrown:
+     "One fixes a bug in the new raid10 resize code so is relevant to 3.4
+      only.
+    
+      The other fixes a bug in the use of md by dm-raid, so is relevant to
+      any kernel with dm-raid support"
+    
+    * tag 'md-3.4-fixes' of git://neil.brown.name/md:
+      MD: Add del_timer_sync to mddev_suspend (fix nasty panic)
+      md/raid10: set dev_sectors properly when resizing devices in array.
+
+commit 31ae98359d26ff89b745c4f8094093cbf6ccbdc6
+tree 26f2c1ebc2d0485de222f13ebf812456ee8a7cb8
+parent 31ae98359d26ff89b745c4f8094093cbf6ccbdc6
+parent 0d9f4f135eb6dea06bdcb7065b1e4ff78274a5e9
+author Linus Torvalds <torvalds@linux-foundation.org> 1337273075 -0700
+committer Linus Torvalds <torvalds@linux-foundation.org> 1337273075 -0700
+
+    Simple Commit
+}
+  end
+
+  def test_list_from_string
+    commits = Grit::Commit.list_from_string(nil, @output)
+
+    assert_equal 2, commits.size
+    assert_equal "36a1987cd891fa82d9981886c3abbbe82c428c0d", commits.first.id
+    assert_equal "31ae98359d26ff89b745c4f8094093cbf6ccbdc6", commits.last.id
+    assert_equal "Merge tag 'md-3.4-fixes' of git", commits.first.message[0..30]
+  end
+end
+

--- a/test/test_head.rb
+++ b/test/test_head.rb
@@ -43,6 +43,7 @@ class TestHead < Test::Unit::TestCase
 
   def test_head_count
     assert_equal 5, @r.heads.size
+    assert_equal 5, @r.head_count
   end
 
 

--- a/test/test_remote.rb
+++ b/test/test_remote.rb
@@ -11,4 +11,8 @@ class TestRemote < Test::Unit::TestCase
     remote = @r.remotes.first
     assert_equal %Q{#<Grit::Remote "#{remote.name}">}, remote.inspect
   end
+
+  def test_remote_count
+    assert_equal 4, @r.remote_count
+  end
 end

--- a/test/test_remote.rb
+++ b/test/test_remote.rb
@@ -13,6 +13,6 @@ class TestRemote < Test::Unit::TestCase
   end
 
   def test_remote_count
-    assert_equal 7, @r.remote_count
+    assert_equal 4, @r.remote_count
   end
 end

--- a/test/test_remote.rb
+++ b/test/test_remote.rb
@@ -13,6 +13,6 @@ class TestRemote < Test::Unit::TestCase
   end
 
   def test_remote_count
-    assert_equal 4, @r.remote_count
+    assert_equal 7, @r.remote_count
   end
 end

--- a/test/test_tag.rb
+++ b/test/test_tag.rb
@@ -13,6 +13,10 @@ class TestTag < Test::Unit::TestCase
     assert_equal 5, @r.tags.size
   end
 
+  def test_tag_count
+    assert_equal 5, @r.tag_count
+  end
+
   # list_from_string
 
   def test_list_from_string


### PR DESCRIPTION
In Gitlab the number of tags is shown, using the command `repo.tags.count`. Now we have some very large repositories where this takes a lot of time, and slows down the complete UI.

Instead of first building the list of tags, just to take the size of it, I added a method `count_all` to `Ref`, which can then be used to implement the methods `tag_count`, `head_count` and `remote_count` on `Repo`.

Some timings, to start on the `grit` repository itself:

```

ruby-1.9.3-p125@grit ~/work/git/grit (master) $ irb
1.9.3p125 :001 > require 'grit'
 => true 
1.9.3p125 :002 > repo = Grit::Repo.new('.')
 => #<Grit::Repo "/home/nathan/work/git/grit/.git"> 
1.9.3p125 :003 > repo.tag_count
 => 15 
1.9.3p125 :004 > repo.tags.count
 => 15 
1.9.3p125 :005 > require 'benchmark'
 => true 
1.9.3p125 :006 > Benchmark.measure { repo.tag_count }
 =>   0.000000   0.000000   0.000000 (  0.000788)

1.9.3p125 :007 > Benchmark.measure { repo.tags.count }
 =>   0.030000   0.000000   0.030000 (  0.024960)
```

Then, for good measurement, on our huge repository:

```
ruby-1.9.3-p125@grit ~/work/git/grit (master) $ irb 
1.9.3p125 :001 > require 'grit'
 => true 
1.9.3p125 :002 > require 'benchmark'
 => true 
1.9.3p125 :004 > repo = Grit::Repo.new('../../vasco/git/ttt')
 => #<Grit::Repo "/home/nathan/work/vasco/git/ttt/.git"> 
1.9.3p125 :005 > Benchmark.measure { repo.tag_count }
 =>   0.020000   0.000000   0.020000 (  0.023077)

1.9.3p125 :006 > Benchmark.measure { repo.tags.count }
 =>   4.130000   0.140000   4.270000 (  4.283126)
```

I added tests as well. Any remarks or suggestions?
