### PR TITLE
Parse log with options

### DIFF
--- a/lib/grit/commit.rb
+++ b/lib/grit/commit.rb
@@ -150,7 +150,7 @@ module Grit
         committer = nil
         committed_date = nil
         encoding = nil
-        while lines.present?
+        while !lines.empty?
           line = lines.shift
           if line =~ /^ {4}/
             message_lines << line[4..-1]


### PR DESCRIPTION
Fix git-log when using options, such as -g. Examine token rather than assuming a set ordering of output.

Fixed test failures and rebased from original pull request.

Original pull request https://github.com/mojombo/grit/pull/106.
