### PR TITLE
Add support for filenames with special characters in git diffs.

### DIFF
--- a/grit.gemspec
+++ b/grit.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency('posix-spawn', "~> 0.3.6")
   s.add_dependency('mime-types', "~> 1.15")
   s.add_dependency('diff-lcs', "~> 1.1")
-  s.add_dependency('charlock_holmes', "~> 0.6")
 
   s.add_development_dependency('mocha')
 

--- a/grit.gemspec
+++ b/grit.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency('posix-spawn', "~> 0.3.6")
   s.add_dependency('mime-types', "~> 1.15")
   s.add_dependency('diff-lcs', "~> 1.1")
+  s.add_dependency('charlock_holmes', "~> 0.6")
 
   s.add_development_dependency('mocha')
 

--- a/lib/grit/diff.rb
+++ b/lib/grit/diff.rb
@@ -1,3 +1,6 @@
+require 'charlock_holmes'
+require 'charlock_holmes/string'
+
 module Grit
 
   class Diff
@@ -31,8 +34,8 @@ module Grit
       while !lines.empty?
         m, q1, a_path, q2, b_path = *lines.shift.match(%r{^diff --git ("?)a/(.+?)\1 ("?)b/(.+?)\3$})
 
-        a_path = a_path.gsub(/\\([0-9]{3})/){|c| c[1..-1].oct.chr}.force_encoding('UTF-8')
-        b_path = b_path.gsub(/\\([0-9]{3})/){|c| c[1..-1].oct.chr}.force_encoding('UTF-8')
+        a_path = transcode( a_path.gsub(/\\([0-9]{3})/){|c| c[1..-1].oct.chr} )
+        b_path = transcode( b_path.gsub(/\\([0-9]{3})/){|c| c[1..-1].oct.chr} )
 
         if lines.first =~ /^old mode/
           m, a_mode = *lines.shift.match(/^old mode (\d+)/)
@@ -77,6 +80,22 @@ module Grit
 
       diffs
     end
+
+    private
+
+      def self.transcode(string, target_encoding = 'UTF-8')
+        detected = string.detect_encoding
+
+        if detected.nil? || detected[:encoding].nil? || detected[:encoding] == target_encoding
+          string
+        else
+          begin
+            CharlockHolmes::Converter.convert( string, detected[:encoding], target_encoding )
+          rescue
+            string
+          end
+        end
+      end
   end # Diff
 
 end # Grit

--- a/lib/grit/diff.rb
+++ b/lib/grit/diff.rb
@@ -1,6 +1,3 @@
-require 'charlock_holmes'
-require 'charlock_holmes/string'
-
 module Grit
 
   class Diff

--- a/lib/grit/diff.rb
+++ b/lib/grit/diff.rb
@@ -29,7 +29,10 @@ module Grit
       diffs = []
 
       while !lines.empty?
-        m, a_path, b_path = *lines.shift.match(%r{^diff --git a/(.+?) b/(.+)$})
+        m, q1, a_path, q2, b_path = *lines.shift.match(%r{^diff --git ("?)a/(.+?)\1 ("?)b/(.+?)\3$})
+
+        a_path = a_path.gsub(/\\([0-9]{3})/){|c| c[1..-1].oct.chr}.force_encoding('UTF-8')
+        b_path = b_path.gsub(/\\([0-9]{3})/){|c| c[1..-1].oct.chr}.force_encoding('UTF-8')
 
         if lines.first =~ /^old mode/
           m, a_mode = *lines.shift.match(/^old mode (\d+)/)

--- a/test/fixtures/diff_tree_i18n
+++ b/test/fixtures/diff_tree_i18n
@@ -1,0 +1,6 @@
+diff --git "a/Administrac\314\247a\314\203o-e-Autorizac\314\247a\314\203o.md" "b/Administrac\314\247a\314\203o-e-Autorizac\314\247a\314\203o.md"
+new file mode 100644
+index 0000000..e69de29
+diff --git a/unquoted.md b/unquoted.md
+new file mode 100644
+index 0000000..e69de29

--- a/test/test_diff.rb
+++ b/test/test_diff.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require File.dirname(__FILE__) + '/helper'
 
 class TestDiff < Test::Unit::TestCase
@@ -52,5 +53,19 @@ class TestDiff < Test::Unit::TestCase
     assert_equal 'foobar', diffs[4].a_path
     assert_equal 'foobar', diffs[4].b_path
     assert                 diffs[4].new_file
+  end
+
+  def test_list_from_string_quoted_filenames
+    output = fixture('diff_tree_i18n')
+    diffs = Grit::Diff.list_from_string(@r, output)
+
+    assert_equal "Administração-e-Autorização.md", diffs[0].b_path
+  end
+
+  def test_list_from_string_unquoted_filenames
+    output = fixture('diff_tree_i18n')
+    diffs = Grit::Diff.list_from_string(@r, output)
+
+    assert_equal 'unquoted.md', diffs[1].b_path
   end
 end


### PR DESCRIPTION
When there are special (eg. UTF-8) characters in filenames,
git double-quotes them in diff output.
- New regular expression to grab quoted filenames
- Then gsub gets rid of the double escaped bytes
- Force UTF-8 encoding on the string
