### PR TITLE
Incorrect array access fix

### DIFF
--- a/lib/grit/git-ruby.rb
+++ b/lib/grit/git-ruby.rb
@@ -98,7 +98,7 @@ module Grit
       if File.file?(packref)
         File.readlines(packref).each do |line|
           if m = /^(\w{40}) refs\/.+?\/(.*?)$/.match(line)
-            next if !Regexp.new(Regexp.escape(string) + '$').match(m[3])
+            next if !Regexp.new(Regexp.escape(string) + '$').match(m[2])
             return m[1].chomp
           end
         end


### PR DESCRIPTION
Hi, I've been tracking down a bug today that I traced to Grit accessing the wrong index of the line match when reading packed-refs. It was '3' and should be '2'. This means it's always falling through to git's rev-parse if it gets that far.

Cheers,
Hugh
