### PR TITLE
exclude git directories from git_binary function

### DIFF
--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -76,7 +76,7 @@ module Grit
         @git_binary ||=
           ENV['PATH'].split(':').
             map  { |p| File.join(p, 'git') }.
-            find { |p| File.exist?(p) }
+            find { |p| File.exist?(p) && !File.directory?(p) }
       end
       attr_writer :git_binary
     end


### PR DESCRIPTION
hi all,

I've got an error with git_binary method with following PATH

/Users/gitlab/.rvm/gems/ruby-1.9.3-p194/bin:/Users/gitlab/.rvm/gems/ruby-1.9.3-p194@global/bin:/Users/gitlab/.rvm/rubies/ruby-1.9.3-p194/bin:/Users/gitlab/.rvm/bin:/Users/SoftDromMacmini2/nvm/v0.6.15/bin:/opt/local/bin:/opt/local/sbin:/usr/local:/usr/local/sbin:/opt/local/bin:/opt/local/sbin:/Library/PostgreSQL/8.3/bin:/Library/Ruby/Gems/1.8/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/X11/bin:/usr/local/git/bin:/Users/SoftDromMacmini2/.rvm/bin:/Users/gitlab/.rvm/bin

Interesting moment here is that git_binary splits path by colons and add 'git' string. After that final result will be /usr/local/git - but it's directory. On MacOS this leads to Errno::EACCES: Permission denied – posix_spawnp error.

For example try on any directory
bundle exec ruby -e "require 'posix/spawn'; p POSIX::Spawn::Child.new('/usr')"

As a result we should exclude directories from path search.
