### PR TITLE
Commit timestamps retain timezone info in Ruby 1.9.

### DIFF
--- a/lib/grit/commit.rb
+++ b/lib/grit/commit.rb
@@ -282,12 +282,19 @@ module Grit
     #
     # Returns [String (actor name and email), Time (acted at time)]
     def self.actor(line)
-      m, actor, epoch = *line.match(/^.+? (.*) (\d+) .*$/)
-      [Actor.from_string(actor), Time.at(epoch.to_i)]
+      m, actor, epoch, tz = *line.match(/^.+? (.*) (\d+) ((\-|\+)\d+).*$/)
+      time = Time.at(epoch.to_i)
+      begin
+        time = time.localtime Time.zone_offset(tz) if tz
+      rescue ArgumentError
+        # Leave times in the local timezone in Ruby 1.8.
+      end
+
+      [Actor.from_string(actor), time]
     end
 
     def author_string
-      "%s <%s> %s %+05d" % [author.name, author.email, authored_date.to_i, 800]
+      "%s <%s> %s %+05d" % [author.name, author.email, authored_date.to_i, authored_date.strftime('%z')]
     end
 
     def to_hash

--- a/test/test_commit.rb
+++ b/test/test_commit.rb
@@ -161,8 +161,8 @@ class TestCommit < Test::Unit::TestCase
 
   def test_diffs_with_options
     Git.any_instance.expects(:diff).
-      with({:full_index => true, :M => true}, 
-        '038af8c329ef7c1bae4568b98bd5c58510465493', 
+      with({:full_index => true, :M => true},
+        '038af8c329ef7c1bae4568b98bd5c58510465493',
         '91169e1f5fa4de2eaea3f176461f5dc784796769').
       returns(fixture('diff_mode_only'))
     @c = Commit.create(@r, :id => '91169e1f5fa4de2eaea3f176461f5dc784796769')
@@ -187,14 +187,14 @@ class TestCommit < Test::Unit::TestCase
     assert patch.include?('From: tom <tom@taco.(none)>')
     assert patch.include?('Date: Tue, 20 Nov 2007 17:27:42 -0800')
     assert patch.include?('Subject: [PATCH] fix tests on other machines')
-    assert patch.include?('test/test_reality.rb |   30 +++++++++++++++---------------')
+    assert patch.include?('test/test_reality.rb | 30 +++++++++++++++---------------')
     assert patch.include?('@@ -1,17 +1,17 @@')
     assert patch.include?('+#     recurse(t)')
     assert patch.include?("1.7.")
   end
 
   # patch_id
-  
+
   def test_patch_id
     @c = Commit.create(@r, :id => '80f136f500dfdb8c3e8abf4ae716f875f0a1b57f')
     assert_equal '9450b04e4f83ad0067199c9e9e338197d1835cbb', @c.patch_id


### PR DESCRIPTION
Git commits keep track of the commit time, as well as of the timezone of the committer. This change embeds the timezone info in the commit times returned by grit. I hope you'll find it helpful!
