### PR TITLE
Fix an edge case in rev_parse.

### DIFF
--- a/lib/grit/git-ruby.rb
+++ b/lib/grit/git-ruby.rb
@@ -75,7 +75,10 @@ module Grit
     def rev_parse(options, string)
       raise RuntimeError, "invalid string: #{string.inspect}" unless string.is_a?(String)
 
-      if string =~ /\.\./
+      # Split ranges, but don't split when specifying a ref:path.
+      # Don't split HEAD:some/path/in/repo..txt
+      # Do split sha1..sha2
+      if string !~ /:/ && string =~ /\.\./
         (sha1, sha2) = string.split('..')
         return [rev_parse({}, sha1), rev_parse({}, sha2)]
       end


### PR DESCRIPTION
## The Problem

Calling #rev_parse with a revision to parse that includes a ref and a path that contains `..` in the filename.
Example `HEAD:path/to/file/with/two..dots_in_the_file_name`

This will attempt to split and then rev_parse on the two parts. At best we'll get an error and git will tell us that the path doesn't exist. At worst we'll run into a situation where that fille will exist and we will be returning bad information.
## The Fix

Just don't split on revision specifiers that contain `:`.
