### PR TITLE
use git-mktag for Grit::Tag.create_tag_object

### DIFF
--- a/lib/grit/tag.rb
+++ b/lib/grit/tag.rb
@@ -40,8 +40,11 @@ module Grit
       data << ""
       data << hash[:message]
       data = data.join("\n")
-      sha = repo.git.put_raw_object(data, 'tag')
-      { :sha => sha, :size => data.size }
+
+      repo.git.native(:mktag, {
+        :input => data,
+        :raise => true
+      }).chomp
     end
 
     # Parses the results from `cat-file -p`

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -20,3 +20,10 @@ end
 def jruby?
   defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /jruby/
 end
+
+def temp_repo(repo_name)
+  Dir.mktmpdir do |tmp_dir|
+    FileUtils.cp_r(File.join(File.dirname(__FILE__), repo_name), tmp_dir)
+    yield File.join(tmp_dir, repo_name)
+  end
+end

--- a/test/test_create_tag.rb
+++ b/test/test_create_tag.rb
@@ -1,0 +1,120 @@
+require File.dirname(__FILE__) + '/helper'
+
+# This tests creating a tag object without creating a corresponding ref.
+
+class TestCreateTag < Test::Unit::TestCase
+  def with_test_repo
+    temp_repo("dot_git") do |repo_path|
+      yield Grit::Repo.new(repo_path, :is_bare => true)
+    end
+  end
+
+  def find_tag_by_sha(repo, sha)
+    Grit::Tag.parse_tag_data(repo.git.get_raw_object(sha))
+  end
+
+  def test_create_tag_with_no_tagger
+    with_test_repo do |repo|
+      master_sha = repo.get_head("master").commit.sha
+
+      tag_sha = Grit::Tag.create_tag_object(repo, {
+        :object => master_sha,
+        :type   => "commit",
+        :tag    => "tag_of_master"
+      })
+
+      assert_not_nil tag_sha
+
+      tag = find_tag_by_sha(repo, tag_sha)
+
+      assert_not_nil tag
+      assert_not_nil tag[:tag_date]
+      assert_equal "tag_of_master", tag[:tag]
+      assert_equal master_sha,      tag[:object]
+      assert_equal "commit",        tag[:type]
+      assert_equal "none",          tag[:tagger].name
+      assert_equal "none@none",     tag[:tagger].email
+      assert_equal "",              tag[:message]
+    end
+  end
+
+  def test_create_tag_with_tagger
+    with_test_repo do |repo|
+      master_sha = repo.get_head("master").commit.sha
+
+      tag_sha = Grit::Tag.create_tag_object(repo, {
+        :object => master_sha,
+        :type   => "commit",
+        :tag    => "tag_of_master",
+        :tagger => {
+          :name  => "Scott Chacon",
+          :email => "schacon@gmail.com",
+          :date  => Time.utc(2012, 1, 1).to_s
+        }
+      })
+
+      assert_not_nil tag_sha
+
+      tag = find_tag_by_sha(repo, tag_sha)
+
+      assert_not_nil tag
+      assert_equal "tag_of_master",      tag[:tag]
+      assert_equal master_sha,           tag[:object]
+      assert_equal "commit",             tag[:type]
+      assert_equal "Scott Chacon",       tag[:tagger].name
+      assert_equal "schacon@gmail.com",  tag[:tagger].email
+      assert_equal Time.utc(2012, 1, 1), tag[:tag_date]
+      assert_equal "",                   tag[:message]
+    end
+  end
+
+  def test_create_tag_with_message
+    with_test_repo do |repo|
+      master_sha = repo.get_head("master").commit.sha
+
+      tag_sha = Grit::Tag.create_tag_object(repo, {
+        :object  => master_sha,
+        :type    => "commit",
+        :tag     => "tag_of_master",
+        :message => "test message"
+      })
+
+      assert_not_nil tag_sha
+
+      tag = find_tag_by_sha(repo, tag_sha)
+
+      assert_not_nil tag
+      assert_not_nil tag[:tag_date]
+      assert_equal "tag_of_master", tag[:tag]
+      assert_equal master_sha,      tag[:object]
+      assert_equal "commit",        tag[:type]
+      assert_equal "none",          tag[:tagger].name
+      assert_equal "none@none",     tag[:tagger].email
+      assert_equal "test message",  tag[:message]
+    end
+  end
+
+  def test_create_with_bad_object
+    with_test_repo do |repo|
+      assert_raises(Grit::Git::CommandFailed) do
+        Grit::Tag.create_tag_object(repo, {
+          :object => "deadbeef" * 5,
+          :type   => "commit",
+          :tag    => "tag_of_nonsense"
+        })
+      end
+    end
+  end
+
+  def test_create_with_type_mismatch
+    with_test_repo do |repo|
+      assert_raises(Grit::Git::CommandFailed) do
+        Grit::Tag.create_tag_object(repo, {
+          :object => repo.get_head("master").commit.sha,
+          :type   => "blob",
+          :tag    => "tag_of_wrong_type"
+        })
+      end
+    end
+  end
+end

--- a/test/test_repo.rb
+++ b/test/test_repo.rb
@@ -5,36 +5,27 @@ class TestRepo < Test::Unit::TestCase
     @r = Repo.new(GRIT_REPO)
   end
 
-  def create_temp_repo(clone_path)
-    filename = 'git_test' + Time.now.to_i.to_s + rand(300).to_s.rjust(3, '0')
-    tmp_path = File.join("/tmp/", filename)
-    FileUtils.mkdir_p(tmp_path)
-    FileUtils.cp_r(clone_path, tmp_path)
-    File.join(tmp_path, 'dot_git')
-  end
-
   def test_update_refs_packed
-    gpath = create_temp_repo(File.join(File.dirname(__FILE__), *%w[dot_git]))
-    @git = Grit::Repo.new(gpath, :is_bare => true)
+    temp_repo("dot_git") do |repo_path|
+      git = Grit::Repo.new(repo_path, :is_bare => true)
 
-    # new and existing
-    test   = 'ac9a30f5a7f0f163bbe3b6f0abf18a6c83b06872'
-    master = 'ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a'
+      # new and existing
+      test   = 'ac9a30f5a7f0f163bbe3b6f0abf18a6c83b06872'
+      master = 'ca8a30f5a7f0f163bbe3b6f0abf18a6c83b0687a'
 
-    @git.update_ref('testref', test)
-    new_t = @git.get_head('testref').commit.sha
-    assert new_t != master
+      git.update_ref('testref', test)
+      new_t = git.get_head('testref').commit.sha
+      assert new_t != master
 
-    @git.update_ref('master', test)
-    new_m = @git.get_head('master').commit.sha
-    assert new_m != master
+      git.update_ref('master', test)
+      new_m = git.get_head('master').commit.sha
+      assert new_m != master
 
-    old = @git.get_head('nonpack').commit.sha
-    @git.update_ref('nonpack', test)
-    newp = @git.get_head('nonpack').commit.sha
-    assert newp != old
-
-    FileUtils.rm_r(gpath)
+      old = git.get_head('nonpack').commit.sha
+      git.update_ref('nonpack', test)
+      newp = git.get_head('nonpack').commit.sha
+      assert newp != old
+    end
   end
 
   # new


### PR DESCRIPTION
Grit::Tag.create_tag_object currently writes a raw object to the repository without doing any sanity checking. This means that invalid tag objects can be created and cause problems in the repo.

This changes the method to use `git-mktag` which will blow up and decline to create invalid tags.
