### PR TITLE
Make refs support submodules

### DIFF
--- a/lib/grit/git-ruby.rb
+++ b/lib/grit/git-ruby.rb
@@ -116,6 +116,10 @@ module Grit
     def refs(options, prefix)
       refs = []
       already = {}
+
+      # submodule
+      @git_dir = File.read(@git_dir)[/gitdir: (.*)/, 1] if File.file?(@git_dir)
+
       Dir.chdir(@git_dir) do
         files = Dir.glob(prefix + '/**/*')
         files.each do |ref|


### PR DESCRIPTION
In a submodule the git_dir is actually a file which contains the location of the actual git dir in the format gitdir: my/actual/dir.

I've already verified manually that it solves my issue (https://github.com/aanand/git-up/issues/31) but I'm quite new to ruby and grit so I could use some advice on how to write the unit tests.
