### PR TITLE
Support Ruby >= 2.0 not only 1.9

### DIFF
--- a/lib/grit/ruby1.9.rb
+++ b/lib/grit/ruby1.9.rb
@@ -1,5 +1,5 @@
 class String
-  if ((defined? RUBY_VERSION) && (RUBY_VERSION[0..2] == "1.9" || RUBY_VERSION[0].to_i >= 2))
+  if ((defined? RUBY_VERSION) && (RUBY_VERSION[0..2] == "1.9" || RUBY_VERSION.split(".")[0].to_i >= 2))
     def getord(offset); self[offset].ord; end
   else
     alias :getord :[]

--- a/lib/grit/ruby1.9.rb
+++ b/lib/grit/ruby1.9.rb
@@ -1,5 +1,5 @@
 class String
-  if ((defined? RUBY_VERSION) && (RUBY_VERSION[0..2] == "1.9"))
+  if ((defined? RUBY_VERSION) && (RUBY_VERSION[0..2] == "1.9" || RUBY_VERSION[0].to_i >= 2))
     def getord(offset); self[offset].ord; end
   else
     alias :getord :[]


### PR DESCRIPTION
Current version doesn't work with ruby 2.0 because of hardcoded "1.9"... that wasn't very good idea took me some time till found...
