### PR TITLE
Fix Diff::LCS dependence

### DIFF
--- a/grit.gemspec
+++ b/grit.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('posix-spawn', "~> 0.3.6")
   s.add_dependency('mime-types', "~> 1.15")
-  s.add_dependency('diff-lcs', "~> 1.1")
+  s.add_dependency('diff-lcs', "~> 1.2")
 
   s.add_development_dependency('mocha')
 

--- a/grit.gemspec
+++ b/grit.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('posix-spawn', "~> 0.3.6")
   s.add_dependency('mime-types', "~> 1.15")
-  s.add_dependency('diff-lcs', "~> 1.2")
+  s.add_dependency('diff-lcs')
 
   s.add_development_dependency('mocha')
 


### PR DESCRIPTION
RSpec of the latest version is not installed because of the dependence of Diff::LCS of an old version.
