### PR TITLE
Atomic object writes

### DIFF
--- a/lib/grit/git-ruby/internal/loose.rb
+++ b/lib/grit/git-ruby/internal/loose.rb
@@ -66,6 +66,7 @@ module Grit
         def safe_write(path, content)
           Tempfile.open("tmp_obj_", File.dirname(path), :opt => "wb") do |f|
             f.write content
+            f.fsync
             f.close
             begin
               File.link(f.path, path)


### PR DESCRIPTION
We occasionally see corrupted empty loose object files on GitHub after a machine failover. The problem is that Grit is not as careful with its object writes as Git itself. This PR should fix that.

/cc @rtomayko 
