### PR TITLE
Index - remove empty directories

### DIFF
--- a/lib/grit.rb
+++ b/lib/grit.rb
@@ -8,6 +8,7 @@ require 'time'
 require 'timeout'
 require 'logger'
 require 'digest/sha1'
+require 'set'
 
 # third party
 

--- a/test/test_rubygit_index.rb
+++ b/test/test_rubygit_index.rb
@@ -121,4 +121,20 @@ class TestRubyGitIndex < Test::Unit::TestCase
     b = @git.commits.first.tree/'README.txt'
     assert_equal 'e45d6b418e34951ddaa3e78e4fc4d3d92a46d3d1', b.id
   end
+
+  # deleting the contents of a directory should delete the directory itself
+  def test_delete_dirs
+    i = @git.index
+    i.read_tree(@git.commits.first.tree.id)
+    %w(pack.rb loose.rb raw_object.rb mmap.rb).each {|f| i.delete(File.join('lib/grit/git-ruby/internal', f))}
+    i.commit('message', [@git.commits.first], @user, nil, 'master')
+    assert !(@git.commits.first.tree / 'lib/grit/git-ruby').contents.map {|c| c.name}.include?('internal')
+        
+    i = @git.index
+    i.read_tree(@git.commits.first.tree.id)
+    %w(object.rb repository.rb).each {|f| i.delete(File.join('lib/grit/git-ruby', f))}
+    i.commit('message', [@git.commits.first], @user, nil, 'master')
+    assert !(@git.commits.first.tree / 'lib/grit').contents.map {|c| c.name}.include?('git-ruby')
+  end
+
 end

--- a/test/test_rubygit_index.rb
+++ b/test/test_rubygit_index.rb
@@ -137,4 +137,12 @@ class TestRubyGitIndex < Test::Unit::TestCase
     assert !(@git.commits.first.tree / 'lib/grit').contents.map {|c| c.name}.include?('git-ruby')
   end
 
+  def test_delete_whole_dir
+    i = @git.index
+    i.read_tree(@git.commits.first.tree.id)
+    i.delete('lib/grit/git-ruby/internal')
+    i.commit('message', [@git.commits.first], @user, nil, 'master')
+    assert !(@git.commits.first.tree / 'lib/grit/git-ruby').contents.map {|c| c.name}.include?('internal')
+  end
+
 end


### PR DESCRIPTION
I ran into a problem while using grit where I couldn't get it to create a commit that deletes a directory. It seemed to me that using index.read_tree(repo.commits.first.id) as a starting point I should be able to use index.delete(file) to remove all files from a directory and that the directory would also be removed. Instead what was happening was that the commit would include an empty directory (tree) which isn't even valid. Even using index.delete(directory_name) specifically wouldn't remove the directory (due to the add method pruning trailing '/' and then the write_tree method later expecting a trailing '/' for directory removals).

I changed the Index class so that the write_tree method recursively merges the pre-existing tree (from read_tree) with whatever changes have been made using the add and delete methods in such a way that empty directories are pruned from the resulting tree hierarchy used for the commit. I also added a test to test_rubygit_index to test the functionality.
