### PR TITLE
Fix deprecation error and warning in test suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,13 @@ task :coverage do
   sh "open coverage/index.html"
 end
 
-require 'rake/rdoctask'
+begin
+  # RDoc 2.4.2+
+  require 'rdoc/task'
+rescue LoadError
+  # RDoc < 2.4.2
+  require 'rake/rdoctask'
+end
 Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title = "#{name} #{version}"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,7 +3,13 @@ require File.join(File.dirname(__FILE__), *%w[.. lib grit])
 require 'rubygems'
 require 'test/unit'
 gem "mocha", ">=0"
-require 'mocha'
+begin
+  # Mocha 0.13+
+  require 'mocha/setup'
+rescue LoadError
+  # Mocha < 0.13
+  require 'mocha'
+end
 
 GRIT_REPO = ENV["GRIT_REPO"] || File.expand_path(File.join(File.dirname(__FILE__), '..'))
 


### PR DESCRIPTION
This change makes it possible to run the grit test suite against new versions of rdoc and removes the warning that shows up when running the tests against new versions of mocha.

The change retains the ability to have the test suite run against the older gem versions.

Please consider merging this to make it easier to keep grit up to date.

Thank you very much!
