### PR TITLE
Make tests pass in Ruby 2.0.

### DIFF
--- a/lib/grit/git-ruby/internal/pack.rb
+++ b/lib/grit/git-ruby/internal/pack.rb
@@ -1,3 +1,5 @@
+# encoding: ascii-8bit
+
 #
 # converted from the gitrb project
 #

--- a/lib/grit/ruby1.9.rb
+++ b/lib/grit/ruby1.9.rb
@@ -1,5 +1,5 @@
 class String
-  if ((defined? RUBY_VERSION) && (RUBY_VERSION[0..2] == "1.9"))
+  if ((defined? RUBY_VERSION) && (RUBY_VERSION[0..2] == "1.9" || RUBY_VERSION.split('.').first.to_i > 1))
     def getord(offset); self[offset].ord; end
   else
     alias :getord :[]


### PR DESCRIPTION
This is a different take on making tests pass in Ruby 2.0. Instead of adding a method to String, it declares the correct encoding for `pack.rb`.
