### PR TITLE
Modified to use UTF-8 encoding. (Works with Ruby 2.0)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ task :coverage do
   sh "open coverage/index.html"
 end
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title = "#{name} #{version}"

--- a/grit.gemspec
+++ b/grit.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = '1.3.5'
 
   s.name              = 'grit'
-  s.version           = '2.5.0'
+  s.version           = '2.5.1'
   s.date              = '2012-04-22'
   s.rubyforge_project = 'grit'
 
@@ -62,7 +62,7 @@ Gem::Specification.new do |s|
     lib/grit/merge.rb
     lib/grit/ref.rb
     lib/grit/repo.rb
-    lib/grit/ruby1.9.rb
+    lib/grit/ruby.rb
     lib/grit/status.rb
     lib/grit/submodule.rb
     lib/grit/tag.rb

--- a/lib/grit.rb
+++ b/lib/grit.rb
@@ -24,8 +24,8 @@ rescue LoadError
   end
 end
 
-# ruby 1.9 compatibility
-require 'grit/ruby1.9'
+# ruby 1.9+ compatibility
+require 'grit/ruby'
 
 # internal requires
 require 'grit/lazy'
@@ -49,7 +49,7 @@ require 'grit/blame'
 require 'grit/merge'
 
 module Grit
-  VERSION = '2.5.0'
+  VERSION = '2.5.1'
 
   class << self
     # Set +debug+ to true to log all git calls and responses

--- a/lib/grit/git-ruby/internal/loose.rb
+++ b/lib/grit/git-ruby/internal/loose.rb
@@ -97,7 +97,8 @@ module Grit
           path = @directory+'/'+sha1[0...2]+'/'+sha1[2..40]
 
           if !File.exists?(path)
-            content = Zlib::Deflate.deflate(store)
+            # Zlib returns a ASCII encoded string
+            content = Zlib::Deflate.deflate(store).force_encoding("UTF-8")
 
             FileUtils.mkdir_p(@directory+'/'+sha1[0...2])
             safe_write(path, content)

--- a/lib/grit/git-ruby/internal/loose.rb
+++ b/lib/grit/git-ruby/internal/loose.rb
@@ -64,10 +64,6 @@ module Grit
 
         # write an object to a temporary file, then atomically rename it
         # into place; this ensures readers never see a half-written file
-        #
-        # Tempfile encoding is set to ASCII so that if someone (like Rails) sets
-        # Encoding.external_encoding to something other than ASCII, grit is
-        # still ok.
         def safe_write(path, content)
           f =
             if RUBY_VERSION >= '1.9'

--- a/lib/grit/git-ruby/internal/loose.rb
+++ b/lib/grit/git-ruby/internal/loose.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 #
 # converted from the gitrb project
 #
@@ -63,6 +64,10 @@ module Grit
 
         # write an object to a temporary file, then atomically rename it
         # into place; this ensures readers never see a half-written file
+        #
+        # Tempfile encoding is set to ASCII so that if someone (like Rails) sets
+        # Encoding.external_encoding to something other than ASCII, grit is
+        # still ok.
         def safe_write(path, content)
           f =
             if RUBY_VERSION >= '1.9'
@@ -97,7 +102,6 @@ module Grit
           path = @directory+'/'+sha1[0...2]+'/'+sha1[2..40]
 
           if !File.exists?(path)
-            # Zlib returns a ASCII encoded string
             content = Zlib::Deflate.deflate(store).force_encoding("UTF-8")
 
             FileUtils.mkdir_p(@directory+'/'+sha1[0...2])

--- a/lib/grit/git-ruby/internal/pack.rb
+++ b/lib/grit/git-ruby/internal/pack.rb
@@ -1,4 +1,3 @@
-# encoding: ascii-8bit
 #
 # converted from the gitrb project
 #
@@ -57,8 +56,8 @@ module Grit
             return
           end
 
-          # read header
-          sig = idxfile.read(4)
+          # read header - read returns ASCII
+          sig = idxfile.read(4).force_encoding("UTF-8")
           ver = idxfile.read(4).unpack("N")[0]
 
           if sig == PACK_IDX_SIGNATURE

--- a/lib/grit/git-ruby/internal/pack.rb
+++ b/lib/grit/git-ruby/internal/pack.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 #
 # converted from the gitrb project
 #
@@ -56,7 +57,9 @@ module Grit
             return
           end
 
-          # read header - read returns ASCII
+          # read header
+          # File.read return a ASCII-8BIT encoded string. Since we're comparing
+          # sig against a source file string we force the encoding on it to UTF-8.
           sig = idxfile.read(4).force_encoding("UTF-8")
           ver = idxfile.read(4).unpack("N")[0]
 

--- a/lib/grit/git-ruby/internal/pack.rb
+++ b/lib/grit/git-ruby/internal/pack.rb
@@ -1,3 +1,4 @@
+# encoding: ascii-8bit
 #
 # converted from the gitrb project
 #
@@ -14,7 +15,7 @@ require 'grit/git-ruby/internal/raw_object'
 require 'grit/git-ruby/internal/file_window'
 
 PACK_SIGNATURE = "PACK"
-PACK_IDX_SIGNATURE = "\377tOc".force_encoding('ASCII-8BIT')
+PACK_IDX_SIGNATURE = "\377tOc"
 
 module Grit
   module GitRuby

--- a/lib/grit/git-ruby/internal/pack.rb
+++ b/lib/grit/git-ruby/internal/pack.rb
@@ -14,7 +14,7 @@ require 'grit/git-ruby/internal/raw_object'
 require 'grit/git-ruby/internal/file_window'
 
 PACK_SIGNATURE = "PACK"
-PACK_IDX_SIGNATURE = "\377tOc"
+PACK_IDX_SIGNATURE = "\377tOc".force_encoding('ASCII-8BIT')
 
 module Grit
   module GitRuby

--- a/lib/grit/ruby.rb
+++ b/lib/grit/ruby.rb
@@ -1,5 +1,5 @@
 class String
-  if ((defined? RUBY_VERSION) && (RUBY_VERSION[0..2] == "1.9"))
+  if ((defined? RUBY_VERSION) && (RUBY_VERSION[0..2].to_f >= 1.9))
     def getord(offset); self[offset].ord; end
   else
     alias :getord :[]

--- a/lib/grit/ruby.rb
+++ b/lib/grit/ruby.rb
@@ -1,5 +1,5 @@
 class String
-  if ((defined? RUBY_VERSION) && (RUBY_VERSION[0..2].to_f >= 1.9))
+  if ((defined? RUBY_VERSION) && (RUBY_VERSION[0..2] >= "1.9"))
     def getord(offset); self[offset].ord; end
   else
     alias :getord :[]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), *%w[.. lib grit])
 require 'rubygems'
 require 'test/unit'
 gem "mocha", ">=0"
-require 'mocha'
+require 'mocha/setup'
 
 GRIT_REPO = ENV["GRIT_REPO"] || File.expand_path(File.join(File.dirname(__FILE__), '..'))
 

--- a/test/test_git.rb
+++ b/test/test_git.rb
@@ -10,7 +10,7 @@ class TestGit < Test::Unit::TestCase
   end
 
   def test_method_missing
-    assert_match(/^git version [\w\.]*$/, @git.version)
+    assert_match(/^git version [\w\.]*[\w\.\-\(\) ]*$/, @git.version)
   end
 
   def test_logs_stderr


### PR DESCRIPTION
- Set encoding of strings to be UTF-8 and force encodings when making string comparisons.
- Updated ruby version check for 2.0
- Fixed deprecated warnings
- Fixed test for OSX version of git
- Tested on 1.9.3-p194 and 2.0.0
