### PR TITLE
Use --work-tree in 'native' git method

### DIFF
--- a/lib/grit/git.rb
+++ b/lib/grit/git.rb
@@ -282,6 +282,9 @@ module Grit
     #       use that number of seconds; when false or 0, disable timeout.
     #     :base - Set false to avoid passing the --git-dir argument when
     #       invoking the git command.
+    #     :work_dir - Set false to avoid passing the --work-tree argument when
+    #       invoking the git command. (GIT_WORK_TREE or --work-tree=<directory> is
+    #       not allowed without specifying GIT_DIR or --git-dir=<directory>.)
     #     :env - Hash of environment variable key/values that are set on the
     #       child process.
     #     :raise - When set true, commands that exit with a non-zero status
@@ -325,15 +328,18 @@ module Grit
       return run(prefix, cmd, '', options, args) if args[-1].to_s[0] == ?|
 
       # more options
-      input    = options.delete(:input)
-      timeout  = options.delete(:timeout); timeout = true if timeout.nil?
-      base     = options.delete(:base);    base    = true if base.nil?
-      chdir    = options.delete(:chdir)
+      input     = options.delete(:input)
+      timeout   = options.delete(:timeout);  timeout   = true  if timeout.nil?
+      base      = options.delete(:base);     base      = true  if base.nil?
+      work_dir  = options.delete(:work_dir); work_dir  = true  if work_dir.nil?
+      chdir     = options.delete(:chdir)
 
       # build up the git process argv
       argv = []
       argv << Git.git_binary
       argv << "--git-dir=#{git_dir}" if base
+      # GIT_WORK_TREE (or --work-tree=<directory>) not allowed without specifying GIT_DIR (or --git-dir=<directory>)
+      argv << "--work-tree=#{work_tree}" if work_dir && base
       argv << cmd.to_s.tr('_', '-')
       argv.concat(options_to_argv(options))
       argv.concat(args)

--- a/test/test_git.rb
+++ b/test/test_git.rb
@@ -114,7 +114,10 @@ class TestGit < Test::Unit::TestCase
   def test_passing_env_to_native
     args = [
       { 'A' => 'B' },
-      Grit::Git.git_binary, "--git-dir=#{@git.git_dir}", "help", "-a",
+      Grit::Git.git_binary,
+      "--git-dir=#{@git.git_dir}",
+      "--work-tree=#{@git.work_tree}",
+      "help", "-a",
       {:input => nil, :chdir => nil, :timeout => Grit::Git.git_timeout, :max => Grit::Git.git_max_size}
     ]
     p = Grit::Git::Child.new(*args)


### PR DESCRIPTION
There are cases like e.g. when we want to `git diff origin/master` to inspect the changes between the local working directory and another commit/head/whatever, in which the command is executed in a folder other than the repository's one. So, even if the `--git-dir` argument is passed correctly the working directory is not identified as it should and the working dir diff is returned taking into account the PWD. This is fixed by passing the `--work-tree` parameter with the correct value to the git options.
