### PR TITLE
Fix Tempfile args in Ruby 1.9 to use binary enc

### DIFF
--- a/lib/grit/git-ruby/internal/loose.rb
+++ b/lib/grit/git-ruby/internal/loose.rb
@@ -66,7 +66,10 @@ module Grit
         def safe_write(path, content)
           f =
             if RUBY_VERSION >= '1.9'
-              Tempfile.open("tmp_obj_", File.dirname(path), :opt => "wb")
+              Tempfile.open("tmp_obj_",
+                            File.dirname(path),
+                            :binmode => true,
+                            :external_encoding => 'BINARY')
             else
               Tempfile.open("tmp_obj_", File.dirname(path))
             end


### PR DESCRIPTION
Ruby 1.9 MRI doesn't appear to recognize an :opt option to IO::open. It does recognize :mode, which would accept "wb" but Tempfile performs a bitwise OR with that value if provided. It's possible to pass :binmode => true, but because of MRI bug 5917 (fixed in trunk but not in 1.9 releases), specifying binmode does not default to binary encoding, so this is explicitly specified with the :external_encoding option.
