### PR TITLE
Get path of the specific blob and tree

### DIFF
--- a/lib/grit/blob.rb
+++ b/lib/grit/blob.rb
@@ -37,12 +37,12 @@ module Grit
     end
 
     # The path of this blob ( eg. lib/grit/blob.rb )
+    #   +treeish+ is the Commit
     #
     # Returns String
     def path(treeish = 'master')
       revs = @repo.git.native(:ls_tree, {:r => true}, treeish, "| grep #{@id}")
-      revs = revs.split("\n").first
-      path = revs.split("\t").last
+      path = revs.split("\n").first.to_s.split("\t").last
       path
     end
 

--- a/lib/grit/blob.rb
+++ b/lib/grit/blob.rb
@@ -29,6 +29,23 @@ module Grit
       self
     end
 
+    # The repo object of this blob
+    #
+    # Returning Grit::Repo
+    def repo
+      @repo
+    end
+
+    # The path of this blob ( eg. lib/grit/blob.rb )
+    #
+    # Returns String
+    def path(treeish = 'master')
+      revs = @repo.git.native(:ls_tree, {:r => true}, treeish, "| grep #{@id}")
+      revs = revs.split("\n").first
+      path = revs.split("\t").last
+      path
+    end
+
     # The size of this blob in bytes
     #
     # Returns Integer

--- a/lib/grit/tree.rb
+++ b/lib/grit/tree.rb
@@ -36,6 +36,13 @@ module Grit
       Tree.construct(@repo, @id, [])
     end
 
+    # The repo object of this blob
+    #
+    # Returning Grit::Repo
+    def repo
+      @repo
+    end
+
     # Create an unbaked Tree containing just the specified attributes
     #   +repo+ is the Repo
     #   +atts+ is a Hash of instance variable data

--- a/lib/grit/tree.rb
+++ b/lib/grit/tree.rb
@@ -43,6 +43,35 @@ module Grit
       @repo
     end
 
+    # The path of this blob ( eg. lib/grit/git-ruby )
+    #   +treeish+ is the Commit
+    #
+    # Returns String
+    def path(treeish = 'master')
+      @dirs = []
+      @path = ''
+      parent = @repo.tree(treeish)
+      self.loop(parent)
+      @path
+    end
+
+    def loop(parent)
+      @dirs << parent.name if parent.name
+      children = parent.trees
+      if children.collect{ |tree| tree.id }.include?(@id)
+        @dirs << name
+        @path = @dirs.join('/')
+      else
+        if children.count > 0
+          children.each do |child|
+            self.loop(child)
+          end
+        else
+          @dirs.delete(parent.name)
+        end
+      end
+    end    
+
     # Create an unbaked Tree containing just the specified attributes
     #   +repo+ is the Repo
     #   +atts+ is a Hash of instance variable data


### PR DESCRIPTION
I add instance method to get path of blob and tree (and also add method to get repo)
# Usage
### Tree

``` ruby
@tree = @repo.tree/"lib/grit"
@tree.path 
#=> "lib/grit"
```

And you also set specific commit like this

``` ruby
commit = @repo.commits.first
@tree = @repo.tree/"lib/grit"
@tree.path(commit)
#=> "lib/grit"
```
### Blob

Blob is the almost same

``` ruby
@blob = @repo.tree/"lib/grit/blob.rb"
@blob.path
#=> "lib/grit/blob.rb"
```

And you also set specific commit like this

``` ruby
commit = @repo.commits.first
@blob = @repo.tree/"lib/grit/blob.rb"
@blob.path(commit) 
#=> "lib/grit/blob.rb"
```
