### PR TITLE
replace rake/rdoctask with rdoc/task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ task :coverage do
   sh "open coverage/index.html"
 end
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title = "#{name} #{version}"


### PR DESCRIPTION
I encountered an error when I ran `rake test` (Ruby version: 1.9.3-p448)

![screen shot 2013-08-26 at 7 56 52 pm](https://f.cloud.github.com/assets/5047/1025550/af79437c-0e47-11e3-97c5-2129bafab3df.png)
