### PR TITLE
Improve gitmodules file parsing

### DIFF
--- a/lib/grit/submodule.rb
+++ b/lib/grit/submodule.rb
@@ -60,12 +60,12 @@ module Grit
       current = nil
 
       lines.each do |line|
-        if line =~ /^\[submodule "(.+)"\]$/
+        if line =~ /^\[submodule\s+"(.+)"\]$/
           current = $1
           config[current] = {}
           config[current]['id'] = (commit.tree/current).id
-        elsif line =~ /^\t(\w+) = (.+)$/
-          config[current][$1] = $2
+        elsif line =~ /^\s*(\w+)\s*=(.+)$/
+          config[current][$1] = $2.strip
           config[current]['id'] = (commit.tree/$2).id if $1 == 'path'
         else
           # ignore

--- a/test/fixtures/gitmodules
+++ b/test/fixtures/gitmodules
@@ -4,3 +4,7 @@
 [submodule "test/glowstick"]
 	path = test/glowstick
 	url = git://github.com/mojombo/glowstick
+# test various indentation and spacing
+[submodule   "spacetest"]
+path = 		test/spacetest   
+  url 	= git://github.com/spacetest

--- a/test/test_submodule.rb
+++ b/test/test_submodule.rb
@@ -19,6 +19,7 @@ class TestSubmodule < Test::Unit::TestCase
 
     assert_equal "git://github.com/mojombo/glowstick", config['test/glowstick']['url']
     assert_equal "git://github.com/mojombo/god", config['god']['url']
+    assert_equal "git://github.com/spacetest", config['spacetest']['url']
   end
 
   def test_config_with_windows_lineendings


### PR DESCRIPTION
Gitmodules file can have arbitrary indentation and spaces in various
places in the middle of the lines.
