### PR TITLE
Allow Grit::Repo to be initialized with a directory that is below the project root.

### DIFF
--- a/test/test_repo.rb
+++ b/test/test_repo.rb
@@ -51,6 +51,19 @@ class TestRepo < Test::Unit::TestCase
     end
   end
 
+  def test_new_should_work_in_subdirectory
+    tmpdir = Dir.mktmpdir
+    gpath = File.join(tmpdir, '.git')
+    subdir_path = File.join(tmpdir, 'test_subdirectory')
+
+    FileUtils.mkdir_p(gpath)
+    FileUtils.mkdir_p(subdir_path)
+
+    assert(Repo.new(subdir_path))
+
+    FileUtils.rm_rf(tmpdir)
+  end
+
   # descriptions
 
   def test_description


### PR DESCRIPTION
This is an issue we ran into when trying to capture the commit sha for a directory when not at the project root. We have scripts that run from within subdirectories.

Something like this:

```
project_directory
   - .git
   - client
   - server
     - deployment scripts
```

We need to run deployment scripts from within the directory of that name.

test_repo didn't fully pass tests, but it looks like that's because it expects to be on a branch named master, which I wasn't. My new test did pass, however.
