### PR TITLE
Clearly state the project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Grit
 ====
 
+**Grit is no longer maintained. Check out [rugged](https://github.com/libgit2/rugged).**
+
 Grit gives you object oriented read/write access to Git repositories via Ruby.
 The main goals are stability and performance. To this end, some of the
 interactions with Git repositories are done by shelling out to the system's


### PR DESCRIPTION
GitHub is transitioning off of Grit. This updates the README to state that grit is unmaintained and points to [libgit2/rugged](https://github.com/libgit2/rugged).

I suggest we close all open pull requests with a link to this pull request, and update the project description to indicate the current state.

/cc @mojombo @rtomayko @peff
