### PR TITLE
grit: fix sort order of newly-created trees with sub-trees

### DIFF
--- a/lib/grit/index.rb
+++ b/lib/grit/index.rb
@@ -186,6 +186,7 @@ module Grit
               mode = mode.to_i.to_s  # leading 0s not allowed
               k = k.split('/').last  # slashes not allowed
               str = "%s %s\0%s" % [mode, k, sha]
+              k += '/' if mode == "40000"
               tree_contents[k] = str
             end
           when String


### PR DESCRIPTION
Git has odd sorting requirements for tree entries. The entries are sorted by name, but sub-trees sort as if they had "/" at the end. That means when you add full paths to the index like this:

```
index.add("foo.bar", "content")
index.add("foo/file", "content")
index.write_tree()
```

the resulting tree ends up sorted correctly (`foo` must come after `foo.bar`, because `/` comes after `.`). But if you provide individual sha1s, like this:

```
index.add("foo.bar", "content")
index.add("foo", [some_tree_sha1, "40000"])
index.write_tree()
```

we end up sorting the entries in the wrong order. Git complains (and may provide incorrect answers for diffs, since we rely on the sort order there).

The fix is fairly straightforward; we already take special care to use a separate sorting key that includes the "/", but we missed the case of a sub-tree being named explicitly by its sha1.

I know Grit is in "deprecated mode", but this is a real bug that can cause corrupt objects to be created. It's probably worth including.
